### PR TITLE
Improved error message for invalid style

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -73,6 +73,7 @@ content type specific operations (such as jp2 generation).
 - 1.7.1 Don't produce empty XML attributes
 - 1.7.2 Allow for 3d content metadata generation
 - 1.8.0 Add in mime-type generation from the shell again to correctly set 3D and other mimetypes (if exif data does not exist)
+- 1.8.1 Adds style to error message when style is invalid
 
 ==Usage
 

--- a/lib/assembly-objectfile/content_metadata.rb
+++ b/lib/assembly-objectfile/content_metadata.rb
@@ -93,7 +93,7 @@ module Assembly
       when :'3d'
         content_type_description = content_type_descriptions[:'3d']
       else
-        raise 'Supplied style not valid'
+        raise "Supplied style (#{style}) not valid"
       end
 
       puts "WARNING - the style #{style} is now deprecated and should not be used." if DEPRECATED_STYLES.include? style

--- a/spec/content_metadata_spec.rb
+++ b/spec/content_metadata_spec.rb
@@ -597,4 +597,13 @@ describe Assembly::ContentMetadata do
     expect(xml.xpath('//resource').length).to be 0
     expect(xml.xpath('//resource/file').length).to be 0
   end
+
+  it 'generates an error message when an unknown style is passed in' do
+    objects = []
+    expect {
+      described_class.create_content_metadata(druid: TEST_DRUID, bundle: :prebundled, style: :borked, objects: objects)
+    }.to raise_error { |error|
+      expect(error.message).to eq('Supplied style (borked) not valid')
+    }
+  end
 end


### PR DESCRIPTION
When a style is invalid in the the `create_content_metadata` method, adds the specific style to the message in the raised Runtime exception. Should help in tracking down errors in the `pre-assembly` app stacktrace. 