### PR TITLE
only obj files need 3d object type

### DIFF
--- a/lib/assembly-objectfile.rb
+++ b/lib/assembly-objectfile.rb
@@ -6,7 +6,7 @@ module Assembly
   VALID_IMAGE_MIMETYPES = ['image/jpeg', 'image/tiff', 'image/tif', 'image/png'].freeze
 
   # if input file has one of these extensions in a 3D object, it will get the 3d resource type
-  VALID_THREE_DIMENSION_EXTENTIONS = ['.obj', '.ply', '.threejs', '.gltf'].freeze
+  VALID_THREE_DIMENSION_EXTENTIONS = ['.obj'].freeze
 
   # the list of mimetypes that will be "trusted" by the unix file command; if a mimetype other than one of these is returned
   #  by the file command, then a check will be made to see if exif data exists...if so, the mimetype returned by the exif data will be used

--- a/spec/content_metadata_spec.rb
+++ b/spec/content_metadata_spec.rb
@@ -511,7 +511,7 @@ describe Assembly::ContentMetadata do
     expect { described_class.create_content_metadata(druid: TEST_DRUID, objects: objects) }.to raise_error(RuntimeError, "File '#{junk_file}' not found")
   end
 
-  it 'generates valid content metadata for a 3d object with two 3d type files and two other supporting files' do
+  it 'generates valid content metadata for a 3d object with one 3d type files and three other supporting files (where one supporting file is a non-viewable but downloadable 3d file)' do
     objects=[Assembly::ObjectFile.new(TEST_OBJ_FILE),Assembly::ObjectFile.new(TEST_PLY_FILE),Assembly::ObjectFile.new(TEST_TIF_INPUT_FILE),Assembly::ObjectFile.new(TEST_PDF_FILE)]
     result = Assembly::ContentMetadata.create_content_metadata(:druid=>TEST_DRUID,:style=>:'3d',:objects=>objects)
     expect(result.class).to be String
@@ -522,12 +522,12 @@ describe Assembly::ContentMetadata do
     expect(xml.xpath('//resource/file').length).to be 4
     expect(xml.xpath('//label').length).to be 4
     expect(xml.xpath('//label')[0].text).to match(/3d 1/)
-    expect(xml.xpath('//label')[1].text).to match(/3d 2/)
-    expect(xml.xpath('//label')[2].text).to match(/File 1/)
-    expect(xml.xpath('//label')[3].text).to match(/File 2/)
+    expect(xml.xpath('//label')[1].text).to match(/File 1/)
+    expect(xml.xpath('//label')[2].text).to match(/File 2/)
+    expect(xml.xpath('//label')[3].text).to match(/File 3/)
     expect(xml.xpath('//resource/file/imageData').length).to be 0
     expect(xml.xpath('//resource')[0].attributes['type'].value).to eq('3d')
-    expect(xml.xpath('//resource')[1].attributes['type'].value).to eq('3d')
+    expect(xml.xpath('//resource')[1].attributes['type'].value).to eq('file')
     expect(xml.xpath('//resource')[2].attributes['type'].value).to eq('file')
     expect(xml.xpath('//resource')[3].attributes['type'].value).to eq('file')
   end


### PR DESCRIPTION
After discussions with @calavano and @dinahhandel we determined that for now only `.obj` files should have contentMetadata resource type='3d'.  Any other file in the object should be resource type=`file`.  As this many change in the future, I left in the filtering logic to allow this extension list to expand again if needed (i.e. we continue to look for an array of potential extensions, even if now the array has only one element for now).