### PR TITLE
Dump deprecated gemspec option

### DIFF
--- a/assembly-objectfile.gemspec
+++ b/assembly-objectfile.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.description = 'Get exif data, file sizes and more.'
   s.license     = 'ALv2'
 
-  s.rubyforge_project = 'assembly-objectfile'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.bindir        = 'exe'


### PR DESCRIPTION
## Why was this change made?

To deal with `NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement`

## Was the documentation updated?

no