### PR TITLE
allow user to specify a preferred order of mimetype generation methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,7 +38,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 107
+  Max: 117
 
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.

--- a/spec/object_file_spec.rb
+++ b/spec/object_file_spec.rb
@@ -25,6 +25,8 @@ describe Assembly::ObjectFile do
     expect(@ai.exif).not_to be nil
     expect(@ai.mimetype).to eq('image/tiff')
     expect(@ai.file_mimetype).to eq('image/tiff')
+    expect(@ai.extension_mimetype).to eq('image/tiff')
+    expect(@ai.exif_mimetype).to eq('image/tiff')
     expect(@ai.object_type).to eq(:image)
     expect(@ai.valid_image?).to eq(true)
     expect(@ai.jp2able?).to eq(true)
@@ -51,6 +53,16 @@ describe Assembly::ObjectFile do
   it 'sets the correct mimetype of plain/text for .obj 3d files' do
     @ai = described_class.new(TEST_OBJ_FILE)
     expect(@ai.mimetype).to eq('text/plain')
+  end
+
+  it 'sets a mimetype of application/x-tgif for .obj 3d files if we prefer the mimetype extension gem over unix file system command' do
+    @ai = described_class.new(TEST_OBJ_FILE, mime_type_order: %i[extension file exif])
+    expect(@ai.mimetype).to eq('application/x-tgif')
+  end
+
+  it 'ignores invald mimetype generation methods and still sets a mimetype of application/x-tgif for .obj 3d files if we prefer the mimetype extension gem over unix file system command' do
+    @ai = described_class.new(TEST_OBJ_FILE, mime_type_order: %i[bogus extension file])
+    expect(@ai.mimetype).to eq('application/x-tgif')
   end
 
   it 'sets the correct mimetype of plain/text for .ply 3d files' do


### PR DESCRIPTION
## Why was this change made?

We sometimes need to get very specific how mimetypes are generated in order to deal with issues like those shown here: https://github.com/sul-dlss/google-books/issues/132

This allows the user to specify the preferred order of mimetype generation for better control in specific use cases.


## Was the documentation updated?
