### PR TITLE
Add deprecation gem

### DIFF
--- a/assembly-objectfile.gemspec
+++ b/assembly-objectfile.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'activesupport', '>= 5.2.0'
+  s.add_dependency 'deprecation'
   s.add_dependency 'dry-struct', '~> 1.0'
   s.add_dependency 'dry-types', '~> 1.1'
   s.add_dependency 'mime-types', '> 3'

--- a/lib/assembly-objectfile/content_metadata.rb
+++ b/lib/assembly-objectfile/content_metadata.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'nokogiri'
+require 'deprecation'
 require 'active_support'
 require 'assembly-objectfile/content_metadata/file'
 require 'assembly-objectfile/content_metadata/file_set'
@@ -98,7 +99,7 @@ module Assembly
     private_class_method :find_common_path
 
     def self.object_level_type(style)
-      puts "WARNING - the style #{style} is now deprecated and should not be used." if DEPRECATED_STYLES.include? style
+      Deprecation.warn(self, "the style #{style} is now deprecated and should not be used. This will be removed in assembly-objectfile 2.0") if DEPRECATED_STYLES.include? style
 
       case style
       when :simple_image


### PR DESCRIPTION
## Why was this change made?

`puts` is not a great way to find where deprecation warnings originate

## Was the documentation updated?
no