### PR TITLE
add webarchive-seed as a new form of content metadata

### DIFF
--- a/lib/assembly-objectfile/content_metadata.rb
+++ b/lib/assembly-objectfile/content_metadata.rb
@@ -14,7 +14,7 @@ module Assembly
   # these are used when :bundle=>:dpg only
 
   DEPRECATED_STYLES = %i[book_with_pdf book_as_image].freeze
-  VALID_STYLES = %i[simple_image simple_book file map document 3d].freeze
+  VALID_STYLES = %i[simple_image simple_book file map document 3d webarchive-seed].freeze
 
   # This class generates content metadata for image files
   class ContentMetadata
@@ -34,6 +34,7 @@ module Assembly
     #                 :book_as_image, as simple_book, but with contentMetadata type="book", resource type="image" (same rule applies for resources with non images)  - NOTE: THIS IS DEPRECATED
     #                 :map, like simple_image, but with contentMetadata type="map", resource type="image"
     #                 :3d, contentMetadata type="3d", ".obj" and other configured 3d extension files go into resource_type="3d", everything else into resource_type="file"
+    #                 :webarchive-seed, contentMetadata type="webarchive-seed", resource type="image"
     #   :bundle = optional - a symbol containing the method of bundling files into resources, allowed values are
     #                 :default = all files get their own resources (default)
     #                 :filename = files with the same filename but different extensions get bundled together in a single resource

--- a/lib/assembly-objectfile/content_metadata/config.rb
+++ b/lib/assembly-objectfile/content_metadata/config.rb
@@ -12,7 +12,7 @@ module Assembly
 
     # Represents a configuration for generating the content metadata
     class Config < Dry::Struct
-      STYLES = %w[image file book map 3d document].freeze
+      STYLES = %w[image file book map 3d document webarchive-seed].freeze
       attribute :auto_labels, Types::Strict::Bool.default(true)
       attribute :flatten_folder_structure, Types::Strict::Bool.default(false)
       attribute :add_file_attributes, Types::Strict::Bool.default(false)

--- a/lib/assembly-objectfile/content_metadata/file_set.rb
+++ b/lib/assembly-objectfile/content_metadata/file_set.rb
@@ -46,7 +46,7 @@ module Assembly
         resource_has_non_images = !(resource_file_types - [:image]).empty?
 
         case style
-        when :simple_image, :map
+        when :simple_image, :map, :'webarchive-seed'
           'image'
         when :file
           'file'

--- a/lib/assembly-objectfile/object_fileable.rb
+++ b/lib/assembly-objectfile/object_fileable.rb
@@ -7,6 +7,7 @@ module Assembly
   # Common behaviors we need for other classes in the gem
   module ObjectFileable
     attr_accessor :file_attributes, :label, :path, :provider_md5, :provider_sha1, :relative_path, :mime_type_order
+
     VALID_MIMETYPE_METHODS = %i[exif file extension].freeze
 
     # @param [String] path full path to the file to be worked with

--- a/spec/content_metadata_spec.rb
+++ b/spec/content_metadata_spec.rb
@@ -333,6 +333,34 @@ RSpec.describe Assembly::ContentMetadata do
       end
     end
 
+    context 'when style is webarchive-seed' do
+      context 'when using a jp2' do
+        it 'generates valid content metadata with exif, adding file attributes' do
+          objects = [Assembly::ObjectFile.new(TEST_JP2_INPUT_FILE)]
+          result = described_class.create_content_metadata(style: :'webarchive-seed', druid: TEST_DRUID, add_exif: true, add_file_attributes: true, objects: objects)
+          expect(result.class).to be String
+          xml = Nokogiri::XML(result)
+          expect(xml.errors.size).to eq 0
+          expect(xml.xpath('//contentMetadata')[0].attributes['type'].value).to eq('webarchive-seed')
+          expect(xml.xpath('//resource').length).to eq 1
+          expect(xml.xpath('//resource/file').length).to eq 1
+          expect(xml.xpath('//resource/file/checksum').length).to eq 2
+          expect(xml.xpath('//resource/file/checksum')[0].text).to eq('b965b5787e0100ec2d43733144120feab327e88c')
+          expect(xml.xpath('//resource/file/checksum')[1].text).to eq('4eb54050d374291ece622d45e84f014d')
+          expect(xml.xpath('//label').length).to eq 1
+          expect(xml.xpath('//label')[0].text).to match(/Image 1/)
+          expect(xml.xpath('//resource')[0].attributes['type'].value).to eq('image')
+          expect(xml.xpath('//resource/file')[0].attributes['size'].value).to eq('306')
+          expect(xml.xpath('//resource/file')[0].attributes['mimetype'].value).to eq('image/jp2')
+          expect(xml.xpath('//resource/file')[0].attributes['publish'].value).to eq('yes')
+          expect(xml.xpath('//resource/file')[0].attributes['preserve'].value).to eq('no')
+          expect(xml.xpath('//resource/file')[0].attributes['shelve'].value).to eq('yes')
+          expect(xml.xpath('//resource/file/imageData')[0].attributes['width'].value).to eq('100')
+          expect(xml.xpath('//resource/file/imageData')[0].attributes['height'].value).to eq('100')
+        end
+      end
+    end
+
     context 'when style=map' do
       context 'when using a single tif and jp2' do
         it 'generates valid content metadata with overriding file attributes, including a default value, and no exif data' do


### PR DESCRIPTION
## Why was this change made?

~~Waiting on #52~~

In order to support registering webarchive_seed objects in pre-assembly, we need to be able to generate the correct form of contentMetadata.  Fixes sul-dlss/pre-assembly#753 when included in https://github.com/sul-dlss/pre-assembly/pull/758

## How was this change tested?

Added a new unit test


## Which documentation and/or configurations were updated?



