### PR TITLE
Relax the ruby requirement to permit Ruby 3

### DIFF
--- a/assembly-objectfile.gemspec
+++ b/assembly-objectfile.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '~> 2.5'
+  s.required_ruby_version = '>= 2.5', '< 4'
 
   s.add_dependency 'activesupport', '>= 5.2.0'
   s.add_dependency 'deprecation'


### PR DESCRIPTION
## Why was this change made?
So that we can upgrade applications that consume this gem to ruby 3


## How was this change tested?



## Which documentation and/or configurations were updated?



