### PR TITLE
allow MiniExifTool errors to surface; don't swallow them

### DIFF
--- a/lib/assembly-objectfile/object_fileable.rb
+++ b/lib/assembly-objectfile/object_fileable.rb
@@ -91,8 +91,6 @@ module Assembly
       @exif ||= begin
         check_for_file
         MiniExiftool.new(path, replace_invalid_chars: '?')
-      rescue StandardError
-        nil
       end
     end
 

--- a/spec/object_file_spec.rb
+++ b/spec/object_file_spec.rb
@@ -214,4 +214,9 @@ describe Assembly::ObjectFile do
     expect(@ai.file_mimetype).to eq('image/tiff')
     expect(@ai.encoding).to eq('binary')
   end
+
+  it 'raises MiniExiftool::Error if exiftool raises one' do
+    object_file = described_class.new('spec/test_data/empty.txt')
+    expect { object_file.exif }.to raise_error(MiniExiftool::Error)
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

We shouldn't silently swallow errors.

Part of #11  (also need to release the gem and have it update with dep-updates)

## How was this change tested? 🤨

specs, integration test using pre-assembly with the gem retrieved from this branch on stage.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



