### PR TITLE
improve version specificaton of development gems

### DIFF
--- a/assembly-objectfile.gemspec
+++ b/assembly-objectfile.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'json'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '~> 1.25'
   s.add_development_dependency 'rubocop-rspec'
-  s.add_development_dependency 'simplecov', '~> 0.17.0' # CodeClimate cannot use SimpleCov >= 0.18.0 for generating test coverage
+  s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
## Why was this change made? 🤔

simplecov gem:  remove restriction that no longer applies;  ensure rubocop is at least 1.xx

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



