### PR TITLE
Refactor object_file_spec and make some object_file methods private

### DIFF
--- a/spec/content_metadata_spec.rb
+++ b/spec/content_metadata_spec.rb
@@ -726,7 +726,6 @@ RSpec.describe Assembly::ContentMetadata do
 
     context 'when not all input files exist' do
       it 'does not generate valid content metadata' do
-        expect(File.exist?(TEST_TIF_INPUT_FILE)).to be true
         junk_file = '/tmp/flim_flam_floom.jp2'
         expect(File.exist?(junk_file)).to be false
         objects = [Assembly::ObjectFile.new(TEST_TIF_INPUT_FILE), Assembly::ObjectFile.new(junk_file)]

--- a/spec/object_file_spec.rb
+++ b/spec/object_file_spec.rb
@@ -25,8 +25,8 @@ describe Assembly::ObjectFile do
     expect(object_file.exif).not_to be_nil
     expect(object_file.mimetype).to eq('image/tiff')
     expect(object_file.file_mimetype).to eq('image/tiff')
-    expect(object_file.extension_mimetype).to eq('image/tiff')
-    expect(object_file.exif_mimetype).to eq('image/tiff')
+    expect(object_file.send(:extension_mimetype)).to eq('image/tiff')
+    expect(object_file.send(:exif_mimetype)).to eq('image/tiff')
     expect(object_file.object_type).to eq(:image)
     expect(object_file.valid_image?).to be(true)
     expect(object_file.jp2able?).to be(true)

--- a/spec/object_file_spec.rb
+++ b/spec/object_file_spec.rb
@@ -3,215 +3,475 @@
 require 'spec_helper'
 
 describe Assembly::ObjectFile do
-  it 'does not run if no input file is passed in' do
-    object_file = described_class.new('')
-    expect { object_file.filesize }.to raise_error(RuntimeError, 'input file  does not exist or is a directory')
-    expect { object_file.sha1 }.to raise_error(RuntimeError, 'input file  does not exist or is a directory')
-    expect { object_file.md5 }.to raise_error(RuntimeError, 'input file  does not exist or is a directory')
+  describe '.common_path' do
+    context 'when common path is 2 nodes out of 4' do
+      it 'returns the common directory' do
+        expect(described_class.common_path(['/Users/peter/00/test.tif', '/Users/peter/05/test.jp2'])).to eq('/Users/peter/')
+      end
+    end
+
+    context 'when common path is 3 nodes out of 4' do
+      it 'returns the common directory' do
+        expect(described_class.common_path(['/Users/peter/00/test.tif', '/Users/peter/00/test.jp2'])).to eq('/Users/peter/00/')
+      end
+    end
+
+    context 'when all in list terminate in diff directories' do
+      it 'returns the common directory' do
+        expect(described_class.common_path(['/Users/peter/00', '/Users/peter/05'])).to eq('/Users/peter/')
+      end
+    end
   end
 
-  it 'returns the common directory of a set of filenames passed into it, where the common part does not terminate on a directory' do
-    expect(described_class.common_path(['/Users/peter/00/test.tif', '/Users/peter/05/test.jp2'])).to eq('/Users/peter/')
+  describe '#new' do
+    context 'without params' do
+      it 'does not set attributes' do
+        object_file = described_class.new('/some/file.txt')
+        expect(object_file.path).to eq('/some/file.txt')
+        expect(object_file.label).to be_nil
+        expect(object_file.file_attributes).to be_nil
+        expect(object_file.provider_sha1).to be_nil
+        expect(object_file.provider_md5).to be_nil
+        expect(object_file.relative_path).to be_nil
+      end
+    end
+
+    context 'with params' do
+      it 'sets attributes to passed params' do
+        object_file = described_class.new('/some/file.txt', label: 'some label', file_attributes: { 'shelve' => 'yes', 'publish' => 'yes', 'preserve' => 'no' }, relative_path: '/tmp')
+        expect(object_file.path).to eq('/some/file.txt')
+        expect(object_file.label).to eq('some label')
+        expect(object_file.file_attributes).to eq('shelve' => 'yes', 'publish' => 'yes', 'preserve' => 'no')
+        expect(object_file.provider_sha1).to be_nil
+        expect(object_file.provider_md5).to be_nil
+        expect(object_file.relative_path).to eq('/tmp')
+      end
+
+      it 'sets provider_md5 to passed param' do
+        object_file = described_class.new('/some/file.txt', provider_md5: 'XYZ')
+        expect(object_file.provider_md5).to eq('XYZ')
+      end
+    end
   end
 
-  it 'returns the common directory of a set of filenames passed into it, where the common part does not terminate on a directory' do
-    expect(described_class.common_path(['/Users/peter/00/test.tif', '/Users/peter/00/test.jp2'])).to eq('/Users/peter/00/')
+  describe '#filename' do
+    it 'returns File.basename' do
+      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      expect(object_file.filename).to eq('test.tif')
+      expect(object_file.filename).to eq(File.basename(TEST_TIF_INPUT_FILE))
+    end
   end
 
-  it 'tells us if an input file is an image' do
-    object_file = described_class.new(TEST_TIF_INPUT_FILE)
-    expect(object_file.image?).to be(true)
-    expect(object_file.exif).not_to be_nil
-    expect(object_file.mimetype).to eq('image/tiff')
-    expect(object_file.file_mimetype).to eq('image/tiff')
-    expect(object_file.send(:extension_mimetype)).to eq('image/tiff')
-    expect(object_file.send(:exif_mimetype)).to eq('image/tiff')
-    expect(object_file.object_type).to eq(:image)
-    expect(object_file.valid_image?).to be(true)
-    expect(object_file.jp2able?).to be(true)
+  describe '#ext' do
+    it 'returns the file extension' do
+      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      expect(object_file.ext).to eq('.tif')
+    end
   end
 
-  it 'tells us information about the input file' do
-    object_file = described_class.new(TEST_TIF_INPUT_FILE)
-    expect(object_file.filename).to eq('test.tif')
-    expect(object_file.ext).to eq('.tif')
-    expect(object_file.filename_without_ext).to eq('test')
-    expect(object_file.dirname).to eq(File.dirname(TEST_TIF_INPUT_FILE))
+  describe '#dirname' do
+    it 'returns the File.dirname' do
+      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      expect(object_file.dirname).to eq(File.dirname(TEST_TIF_INPUT_FILE))
+    end
   end
 
-  it 'sets the correct mimetype of plain/text for .txt files' do
-    object_file = described_class.new(TEST_RES1_TEXT)
-    expect(object_file.mimetype).to eq('text/plain')
+  describe '#filename_without_ext' do
+    it 'returns filename before extension' do
+      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      expect(object_file.filename_without_ext).to eq('test')
+    end
   end
 
-  it 'sets the correct mimetype of plain/text for .xml files' do
-    object_file = described_class.new(TEST_RES1_TEXT)
-    expect(object_file.mimetype).to eq('text/plain')
+  describe '#image?' do
+    context 'with tiff' do
+      it 'true' do
+        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        expect(object_file.image?).to be(true)
+      end
+    end
+
+    context 'with jp2' do
+      it 'true' do
+        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        expect(object_file.image?).to be(true)
+      end
+    end
+
+    context 'with ruby file' do
+      it 'false' do
+        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/object_file_spec.rb')
+        object_file = described_class.new(non_image_file)
+        expect(object_file.image?).to be(false)
+      end
+    end
+
+    context 'with xml' do
+      it 'false' do
+        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
+        object_file = described_class.new(non_image_file)
+        expect(object_file.image?).to be(false)
+      end
+    end
   end
 
-  it 'sets the correct mimetype of plain/text for .obj 3d files' do
-    object_file = described_class.new(TEST_OBJ_FILE)
-    expect(object_file.mimetype).to eq('text/plain')
+  describe '#object_type' do
+    context 'with tiff' do
+      it ':image' do
+        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        expect(object_file.object_type).to eq(:image)
+      end
+    end
+
+    context 'with jp2' do
+      it ':image' do
+        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        expect(object_file.object_type).to eq(:image)
+      end
+    end
+
+    context 'with ruby file' do
+      it ':text' do
+        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/object_file_spec.rb')
+        object_file = described_class.new(non_image_file)
+        expect(object_file.object_type).to eq(:text)
+      end
+    end
+
+    context 'with xml' do
+      it ':application' do
+        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
+        object_file = described_class.new(non_image_file)
+        expect(object_file.object_type).to eq(:application)
+      end
+    end
   end
 
-  it 'sets a mimetype of application/x-tgif for .obj 3d files if we prefer the mimetype extension gem over unix file system command' do
-    object_file = described_class.new(TEST_OBJ_FILE, mime_type_order: %i[extension file exif])
-    expect(object_file.mimetype).to eq('application/x-tgif')
+  describe '#valid_image?' do
+    context 'with tiff' do
+      it 'true' do
+        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        expect(object_file.valid_image?).to be(true)
+      end
+    end
+
+    context 'with tiff resolution 1' do
+      it 'true' do
+        object_file = described_class.new(TEST_RES1_TIF1)
+        expect(object_file.valid_image?).to be(true)
+      end
+    end
+
+    context 'with tiff no color' do
+      it 'true' do
+        object_file = described_class.new(TEST_TIFF_NO_COLOR_FILE)
+        expect(object_file.valid_image?).to be(true)
+      end
+    end
+
+    context 'with jp2' do
+      it 'true' do
+        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        expect(object_file.valid_image?).to be(true)
+      end
+    end
+
+    context 'with ruby file' do
+      it 'false' do
+        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/object_file_spec.rb')
+        object_file = described_class.new(non_image_file)
+        expect(object_file.valid_image?).to be(false)
+      end
+    end
+
+    context 'with xml' do
+      it 'false' do
+        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
+        object_file = described_class.new(non_image_file)
+        expect(object_file.valid_image?).to be(false)
+      end
+    end
   end
 
-  it 'ignores invald mimetype generation methods and still sets a mimetype of application/x-tgif for .obj 3d files if we prefer the mimetype extension gem over unix file system command' do
-    object_file = described_class.new(TEST_OBJ_FILE, mime_type_order: %i[bogus extension file])
-    expect(object_file.mimetype).to eq('application/x-tgif')
+  describe '#mimetype' do
+    # rubocop:disable RSpec/RepeatedExampleGroupBody
+    context 'with .txt file' do
+      it 'plain/text' do
+        object_file = described_class.new(TEST_RES1_TEXT)
+        expect(object_file.mimetype).to eq('text/plain')
+      end
+    end
+
+    context 'with .xml file' do
+      it 'plain/text' do
+        object_file = described_class.new(TEST_RES1_TEXT)
+        expect(object_file.mimetype).to eq('text/plain')
+      end
+    end
+    # rubocop:enable RSpec/RepeatedExampleGroupBody
+
+    context 'with .tif file' do
+      it 'image/tiff' do
+        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        expect(object_file.mimetype).to eq('image/tiff')
+      end
+    end
+
+    context 'with .jp2 file' do
+      it 'image/jp2' do
+        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        expect(object_file.mimetype).to eq('image/jp2')
+      end
+    end
+
+    context 'with .pdf file' do
+      it 'application/pdf' do
+        object_file = described_class.new(TEST_RES1_PDF)
+        expect(object_file.mimetype).to eq('application/pdf')
+      end
+    end
+
+    context 'with .obj (3d) file' do
+      context 'when default preference (unix file system command)' do
+        it 'plain/text' do
+          object_file = described_class.new(TEST_OBJ_FILE)
+          expect(object_file.mimetype).to eq('text/plain')
+        end
+      end
+
+      context 'when mimetype extension gem preferred over unix file system command' do
+        it 'application/x-tgif' do
+          object_file = described_class.new(TEST_OBJ_FILE, mime_type_order: %i[extension file exif])
+          expect(object_file.mimetype).to eq('application/x-tgif')
+        end
+      end
+
+      context 'when invalid first preference mimetype generation' do
+        it 'ignores invalid mimetype generation method and respects valid method preference order' do
+          object_file = described_class.new(TEST_OBJ_FILE, mime_type_order: %i[bogus extension file])
+          expect(object_file.mimetype).to eq('application/x-tgif')
+        end
+      end
+    end
+
+    context 'with .ply 3d file' do
+      it 'text/plain' do
+        object_file = described_class.new(TEST_PLY_FILE)
+        expect(object_file.mimetype).to eq('text/plain')
+      end
+    end
+
+    context 'when exif information is damaged' do
+      it 'gives us the mimetype' do
+        object_file = described_class.new(TEST_FILE_NO_EXIF)
+        expect(object_file.filename).to eq('file_with_no_exif.xml')
+        expect(object_file.ext).to eq('.xml')
+        # we could get either of these mimetypes depending on the OS
+        expect(['text/html', 'application/xml'].include?(object_file.mimetype)).to be true
+      end
+    end
+
+    context 'when .json file' do
+      it 'uses the manual mapping to set the correct mimetype of application/json for a .json file' do
+        object_file = described_class.new(TEST_JSON_FILE)
+        expect(object_file.send(:exif_mimetype)).to be_nil # exif
+        expect(object_file.send(:file_mimetype)).to eq('text/plain') # unix file system command
+        expect(object_file.mimetype).to eq('application/json') # our configured mapping overrides both
+      end
+    end
   end
 
-  it 'sets the correct mimetype of plain/text for .ply 3d files' do
-    object_file = described_class.new(TEST_PLY_FILE)
-    expect(object_file.mimetype).to eq('text/plain')
+  describe '#file_mimetype (unix file system command)' do
+    context 'when .json file' do
+      it 'text/plain' do
+        object_file = described_class.new(TEST_JSON_FILE)
+        expect(object_file.send(:file_mimetype)).to eq('text/plain')
+      end
+    end
+
+    context 'when .tif file' do
+      it 'image/tiff' do
+        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        expect(object_file.send(:file_mimetype)).to eq('image/tiff')
+      end
+    end
   end
 
-  it 'overrides the mimetype generators and uses the manual mapping to set the correct mimetype of application/json for a .json file' do
-    object_file = described_class.new(TEST_JSON_FILE)
-    expect(object_file.exif_mimetype).to be_nil # exif returns nil
-    expect(object_file.file_mimetype).to eq('text/plain') # unix file system command returns plain text
-    expect(object_file.mimetype).to eq('application/json') # but our configured mapping overrides both and returns application/json
+  describe '#dpg_basename' do
+    it 'returns the DPG base name for a file' do
+      test_file = File.join(TEST_INPUT_DIR, 'oo000oo0001_00_001.tif')
+      object_file = described_class.new(test_file)
+      expect(object_file.dpg_basename).to eq('oo000oo0001_001')
+    end
   end
 
-  it 'sets the correct mimetype of image/tiff for .tif files' do
-    object_file = described_class.new(TEST_TIF_INPUT_FILE)
-    expect(object_file.mimetype).to eq('image/tiff')
+  describe '#dpg_folder' do
+    it 'returns the DPG subfolder name for a file' do
+      test_file = File.join(TEST_INPUT_DIR, 'oo000oo0001_05_001.tif')
+      object_file = described_class.new(test_file)
+      expect(object_file.dpg_folder).to eq('05')
+    end
   end
 
-  it 'sets the correct mimetype of image/jp2 for .jp2 files' do
-    object_file = described_class.new(TEST_JP2_INPUT_FILE)
-    expect(object_file.mimetype).to eq('image/jp2')
+  describe '#jp2able?' do
+    context 'with jp2 file' do
+      it 'false' do
+        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        expect(object_file.jp2able?).to be(false)
+      end
+    end
+
+    context 'with tiff resolution 1 file' do
+      it 'true' do
+        object_file = described_class.new(TEST_RES1_TIF1)
+        expect(object_file.jp2able?).to be(true)
+      end
+    end
+
+    context 'with tiff no color file' do
+      it 'true' do
+        object_file = described_class.new(TEST_TIFF_NO_COLOR_FILE)
+        expect(object_file.jp2able?).to be(true)
+      end
+    end
   end
 
-  it 'sets the correct mimetype of application/pdf for .pdf files' do
-    object_file = described_class.new(TEST_RES1_PDF)
-    expect(object_file.mimetype).to eq('application/pdf')
+  describe '#has_color_profile?' do
+    context 'with jp2 file' do
+      it 'true' do
+        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        expect(object_file.has_color_profile?).to be(true)
+      end
+    end
+
+    context 'with tiff file' do
+      it 'true' do
+        object_file = described_class.new(TEST_RES1_TIF1)
+        expect(object_file.has_color_profile?).to be(true)
+      end
+    end
+
+    context 'with tiff no color file' do
+      it 'false' do
+        object_file = described_class.new(TEST_TIFF_NO_COLOR_FILE)
+        expect(object_file.has_color_profile?).to be(false)
+      end
+    end
   end
 
-  it 'gives us the mimetype of a file even if the exif information is damaged' do
-    object_file = described_class.new(TEST_FILE_NO_EXIF)
-    expect(object_file.filename).to eq('file_with_no_exif.xml')
-    expect(object_file.ext).to eq('.xml')
-    expect(['text/html', 'application/xml'].include?(object_file.mimetype)).to be true # we could get either of these mimetypes depending on the OS
+  describe '#md5' do
+    it 'computes md5 for an image file' do
+      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      expect(object_file.md5).to eq('a2400500acf21e43f5440d93be894101')
+    end
+
+    it 'raises RuntimeError if no input file is passed in' do
+      object_file = described_class.new('')
+      expect { object_file.md5 }.to raise_error(RuntimeError, 'input file  does not exist or is a directory')
+    end
   end
 
-  it 'gives us the DPG base name for a file' do
-    test_file = File.join(TEST_INPUT_DIR, 'oo000oo0001_00_001.tif')
-    object_file = described_class.new(test_file)
-    expect(object_file.dpg_basename).to eq('oo000oo0001_001')
+  describe '#sha1' do
+    it 'computes sha1 for an image file' do
+      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      expect(object_file.sha1).to eq('8d11fab63089a24c8b17063d29a4b0eac359fb41')
+    end
+
+    it 'raises RuntimeError if no input file is passed in' do
+      object_file = described_class.new('')
+      expect { object_file.sha1 }.to raise_error(RuntimeError, 'input file  does not exist or is a directory')
+    end
   end
 
-  it 'gives us the DPG subfolder name for a file' do
-    test_file = File.join(TEST_INPUT_DIR, 'oo000oo0001_05_001.tif')
-    object_file = described_class.new(test_file)
-    expect(object_file.dpg_folder).to eq('05')
+  describe '#file_exists?' do
+    it 'false when a valid directory is specified instead of a file' do
+      path = Assembly::PATH_TO_GEM
+      object_file = described_class.new(path)
+      expect(File.exist?(path)).to be true
+      expect(File.directory?(path)).to be true
+      expect(object_file.file_exists?).to be false
+    end
+
+    it 'false when a non-existent file is specified' do
+      path = File.join(Assembly::PATH_TO_GEM, 'file_not_there.txt')
+      object_file = described_class.new(path)
+      expect(File.exist?(path)).to be false
+      expect(File.directory?(path)).to be false
+      expect(object_file.file_exists?).to be false
+    end
   end
 
-  it 'tells us that a jp2 file is not jp2able but does have a color profile' do
-    object_file = described_class.new(TEST_JP2_INPUT_FILE)
-    expect(object_file.image?).to be(true)
-    expect(object_file.object_type).to eq(:image)
-    expect(object_file.valid_image?).to be(true)
-    expect(object_file.jp2able?).to be(false)
-    expect(object_file.has_color_profile?).to be(true)
+  describe '#filesize' do
+    it 'tells us the size of an input file' do
+      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      expect(object_file.filesize).to eq(63_542)
+    end
+
+    it 'raises RuntimeError if no file is passed in' do
+      object_file = described_class.new('')
+      expect { object_file.filesize }.to raise_error(RuntimeError, 'input file  does not exist or is a directory')
+    end
   end
 
-  it 'tells us that a tiff file is jp2able and has a color profile' do
-    object_file = described_class.new(TEST_RES1_TIF1)
-    expect(object_file.image?).to be(true)
-    expect(object_file.object_type).to eq(:image)
-    expect(object_file.valid_image?).to be(true)
-    expect(object_file.jp2able?).to be(true)
-    expect(object_file.has_color_profile?).to be(true)
+  describe '#encoding' do
+    context 'with .tif file' do
+      it 'binary' do
+        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        expect(object_file.send(:encoding)).to eq('binary')
+      end
+    end
+
+    context 'with .txt file' do
+      it 'binary' do
+        object_file = described_class.new(TEST_RES1_TEXT)
+        expect(object_file.send(:encoding)).to eq('us-ascii')
+      end
+    end
   end
 
-  it 'tells us that a tiff file is not jp2able and is not valid since it has no profile' do
-    object_file = described_class.new(TEST_TIFF_NO_COLOR_FILE)
-    expect(object_file.image?).to be(true)
-    expect(object_file.object_type).to eq(:image)
-    expect(object_file.valid_image?).to be(true)
-    expect(object_file.jp2able?).to be(true)
-    expect(object_file.has_color_profile?).to be(false)
+  describe '#exif' do
+    it 'returns MiniExiftool object' do
+      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      expect(object_file.exif).not_to be_nil
+      expect(object_file.exif.class).to eq MiniExiftool
+    end
+
+    it 'raises MiniExiftool::Error if exiftool raises one' do
+      object_file = described_class.new('spec/test_data/empty.txt')
+      expect { object_file.exif }.to raise_error(MiniExiftool::Error)
+    end
   end
 
-  it 'computes checksums for an image file' do
-    object_file = described_class.new(TEST_TIF_INPUT_FILE)
-    expect(object_file.md5).to eq('a2400500acf21e43f5440d93be894101')
-    expect(object_file.sha1).to eq('8d11fab63089a24c8b17063d29a4b0eac359fb41')
+  describe '#extension_mimetype' do
+    # mime-types gem, based on a file extension lookup
+    context 'with .obj file' do
+      it 'application/x-tgif' do
+        object_file = described_class.new(TEST_OBJ_FILE)
+        expect(object_file.send(:extension_mimetype)).to eq('application/x-tgif')
+      end
+    end
+
+    context 'with .tif file' do
+      it 'image/tiff' do
+        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        expect(object_file.send(:extension_mimetype)).to eq('image/tiff')
+      end
+    end
   end
 
-  it 'indicates that the file is not found when a valid directory is supplied instead of a file or when an invalid file path is specified' do
-    path = Assembly::PATH_TO_GEM
-    object_file = described_class.new(path)
-    expect(File.exist?(path)).to be true
-    expect(File.directory?(path)).to be true
-    expect(object_file.file_exists?).to be false
+  describe '#exif_mimetype' do
+    context 'with .tif file' do
+      it 'image/tiff' do
+        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        expect(object_file.send(:exif_mimetype)).to eq('image/tiff')
+      end
+    end
 
-    path = File.join(Assembly::PATH_TO_GEM, 'bogus.txt')
-    object_file = described_class.new(path)
-    expect(File.exist?(path)).to be false
-    expect(File.directory?(path)).to be false
-    expect(object_file.file_exists?).to be false
-  end
-
-  it 'sets attributes correctly when initializing' do
-    object_file = described_class.new('/some/file.txt')
-    expect(object_file.path).to eq('/some/file.txt')
-    expect(object_file.label).to be_nil
-    expect(object_file.file_attributes).to be_nil
-    expect(object_file.provider_sha1).to be_nil
-    expect(object_file.provider_md5).to be_nil
-    expect(object_file.relative_path).to be_nil
-
-    object_file = described_class.new('/some/file.txt', label: 'some label', file_attributes: { 'shelve' => 'yes', 'publish' => 'yes', 'preserve' => 'no' }, relative_path: '/tmp')
-    expect(object_file.path).to eq('/some/file.txt')
-    expect(object_file.label).to eq('some label')
-    expect(object_file.file_attributes).to eq('shelve' => 'yes', 'publish' => 'yes', 'preserve' => 'no')
-    expect(object_file.provider_sha1).to be_nil
-    expect(object_file.provider_md5).to be_nil
-    expect(object_file.relative_path).to eq('/tmp')
-  end
-
-  it 'sets md5_provider attribute' do
-    object_file = described_class.new('/some/file.txt', provider_md5: 'XYZ')
-    expect(object_file.provider_md5).to eq('XYZ')
-  end
-
-  it 'tells us if an input file is not an image' do
-    non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/object_file_spec.rb')
-    expect(File.exist?(non_image_file)).to be true
-    object_file = described_class.new(non_image_file)
-    expect(object_file.image?).to be(false)
-    expect(object_file.object_type).not_to eq(:image)
-    expect(object_file.valid_image?).to be(false)
-
-    non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
-    expect(File.exist?(non_image_file)).to be true
-    object_file = described_class.new(non_image_file)
-    expect(object_file.image?).to be(false)
-    expect(object_file.object_type).not_to eq(:image)
-    expect(object_file.valid_image?).to be(false)
-  end
-
-  it 'tells us the size of an input file' do
-    expect(File.exist?(TEST_TIF_INPUT_FILE)).to be true
-    object_file = described_class.new(TEST_TIF_INPUT_FILE)
-    expect(object_file.filesize).to eq(63_542)
-  end
-
-  it 'tells us the mimetype and encoding of an input file' do
-    expect(File.exist?(TEST_TIF_INPUT_FILE)).to be true
-    @ai = described_class.new(TEST_TIF_INPUT_FILE)
-    expect(@ai.mimetype).to eq('image/tiff')
-    expect(@ai.file_mimetype).to eq('image/tiff')
-    expect(@ai.encoding).to eq('binary')
-  end
-
-  it 'raises MiniExiftool::Error if exiftool raises one' do
-    object_file = described_class.new('spec/test_data/empty.txt')
-    expect { object_file.exif }.to raise_error(MiniExiftool::Error)
+    context 'when .json file' do
+      it 'nil' do
+        object_file = described_class.new(TEST_JSON_FILE)
+        expect(object_file.send(:exif_mimetype)).to be_nil
+      end
+    end
   end
 end

--- a/spec/object_file_spec.rb
+++ b/spec/object_file_spec.rb
@@ -19,7 +19,6 @@ describe Assembly::ObjectFile do
   end
 
   it 'tells us if an input file is an image' do
-    expect(File.exist?(TEST_TIF_INPUT_FILE)).to be true
     object_file = described_class.new(TEST_TIF_INPUT_FILE)
     expect(object_file.image?).to be(true)
     expect(object_file.exif).not_to be_nil
@@ -112,7 +111,6 @@ describe Assembly::ObjectFile do
   end
 
   it 'tells us that a jp2 file is not jp2able but does have a color profile' do
-    expect(File.exist?(TEST_JP2_INPUT_FILE)).to be true
     object_file = described_class.new(TEST_JP2_INPUT_FILE)
     expect(object_file.image?).to be(true)
     expect(object_file.object_type).to eq(:image)
@@ -122,7 +120,6 @@ describe Assembly::ObjectFile do
   end
 
   it 'tells us that a tiff file is jp2able and has a color profile' do
-    expect(File.exist?(TEST_RES1_TIF1)).to be true
     object_file = described_class.new(TEST_RES1_TIF1)
     expect(object_file.image?).to be(true)
     expect(object_file.object_type).to eq(:image)
@@ -132,7 +129,6 @@ describe Assembly::ObjectFile do
   end
 
   it 'tells us that a tiff file is not jp2able and is not valid since it has no profile' do
-    expect(File.exist?(TEST_TIFF_NO_COLOR_FILE)).to be true
     object_file = described_class.new(TEST_TIFF_NO_COLOR_FILE)
     expect(object_file.image?).to be(true)
     expect(object_file.object_type).to eq(:image)
@@ -142,7 +138,6 @@ describe Assembly::ObjectFile do
   end
 
   it 'computes checksums for an image file' do
-    expect(File.exist?(TEST_TIF_INPUT_FILE)).to be true
     object_file = described_class.new(TEST_TIF_INPUT_FILE)
     expect(object_file.md5).to eq('a2400500acf21e43f5440d93be894101')
     expect(object_file.sha1).to eq('8d11fab63089a24c8b17063d29a4b0eac359fb41')


### PR DESCRIPTION
## Why was this change made? 🤔

two main reasons:

1.  In order to switch from miniexif-tool to ruby-vips (issue #72), it will be much easier to work on it method by method.  I refactored `objectfile_spec.rb` to have the same tests (and more!) but organized them by method.

2.  maintaining a class is easier when methods that can be private (because they are only used by the class) are made private.  I carefully checked that methods moved to private were not used by any downstream consumers.  (There could be more to move, but it was too hard to search on methods such as ".filename".)

## How was this change tested? 🤨

unit tests;  ran preassembly integration test to ensure we create jp2 from jpeg without trouble.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



