### PR TITLE
add debugging gem to the gemspec and not just spec_helper

### DIFF
--- a/assembly-objectfile.gemspec
+++ b/assembly-objectfile.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri'
 
   s.add_development_dependency 'json'
+  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 1.25'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'simplecov'
 SimpleCov.start
 
 require File.expand_path("#{File.dirname(__FILE__)}/../config/boot")
-require 'byebug'
+require 'pry-byebug'
 
 RSpec.configure do |config|
   config.order = 'random'


### PR DESCRIPTION
## Why was this change made? 🤔

1.  `spec_helper` required byebug but it wasn't in the gemspec
2. I was using `pry-byebug` during debugging for a PR that didn't make the cut.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



