### PR TITLE
remove unused has_color_profile? method

### DIFF
--- a/lib/assembly-objectfile/object_file.rb
+++ b/lib/assembly-objectfile/object_file.rb
@@ -175,16 +175,6 @@ module Assembly
       mimetype == 'image/jp2' || jp2able?
     end
 
-    # @return [Boolean] true if image has a color profile, false if not.
-    # @example
-    #   source_img = Assembly::ObjectFile.new('/input/path_to_file.tif')
-    #   puts source_img.has_color_profile? # true
-    def has_color_profile?
-      return false unless exif
-
-      exif['profiledescription'] || exif['colorspace'] ? true : false
-    end
-
     # Examines the input image for validity to create a jp2.  Same as valid_image? but also confirms
     # the existence of a profile description and further restricts mimetypes.
     # It is used by the assembly robots to decide if a jp2 will be created and is also called before

--- a/spec/assembly/object_file_spec.rb
+++ b/spec/assembly/object_file_spec.rb
@@ -333,29 +333,6 @@ describe Assembly::ObjectFile do
     end
   end
 
-  describe '#has_color_profile?' do
-    context 'with jp2 file' do
-      it 'true' do
-        object_file = described_class.new(TEST_JP2_INPUT_FILE)
-        expect(object_file.has_color_profile?).to be(true)
-      end
-    end
-
-    context 'with tiff file' do
-      it 'true' do
-        object_file = described_class.new(TEST_RES1_TIF1)
-        expect(object_file.has_color_profile?).to be(true)
-      end
-    end
-
-    context 'with tiff no color file' do
-      it 'false' do
-        object_file = described_class.new(TEST_TIFF_NO_COLOR_FILE)
-        expect(object_file.has_color_profile?).to be(false)
-      end
-    end
-  end
-
   describe '#md5' do
     it 'computes md5 for an image file' do
       object_file = described_class.new(TEST_TIF_INPUT_FILE)


### PR DESCRIPTION
## Why was this change made? 🤔

The method is never used.  I did a github search on sul-dlss and a did a local search on my cloned sul-dlss repos in the app and lib directories.

closes #72

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



