### PR TITLE
remove unused constants in spec_helper

### DIFF
--- a/lib/assembly-objectfile.rb
+++ b/lib/assembly-objectfile.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module Assembly
-  # the path to the gem, used to access profiles stored with the gem
-  PATH_TO_GEM = File.expand_path("#{File.dirname(__FILE__)}/..")
-
   # If input image is not one of these mime types, it will not be regarded as a valid image
   # for the purpose of generating a JP2 derivative
   VALID_IMAGE_MIMETYPES = ['image/jpeg', 'image/tiff', 'image/tif', 'image/png'].freeze

--- a/spec/assembly/object_file_spec.rb
+++ b/spec/assembly/object_file_spec.rb
@@ -113,7 +113,7 @@ describe Assembly::ObjectFile do
 
     context 'with ruby file' do
       it 'false' do
-        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
+        non_image_file = File.join(PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
         object_file = described_class.new(non_image_file)
         expect(object_file.image?).to be(false)
       end
@@ -121,7 +121,7 @@ describe Assembly::ObjectFile do
 
     context 'with xml' do
       it 'false' do
-        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
+        non_image_file = File.join(PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
         object_file = described_class.new(non_image_file)
         expect(object_file.image?).to be(false)
       end
@@ -145,7 +145,7 @@ describe Assembly::ObjectFile do
 
     context 'with ruby file' do
       it ':text' do
-        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
+        non_image_file = File.join(PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
         object_file = described_class.new(non_image_file)
         expect(object_file.object_type).to eq(:text)
       end
@@ -153,7 +153,7 @@ describe Assembly::ObjectFile do
 
     context 'with xml' do
       it ':application' do
-        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
+        non_image_file = File.join(PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
         object_file = described_class.new(non_image_file)
         expect(object_file.object_type).to eq(:application)
       end
@@ -191,7 +191,7 @@ describe Assembly::ObjectFile do
 
     context 'with ruby file' do
       it 'false' do
-        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
+        non_image_file = File.join(PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
         object_file = described_class.new(non_image_file)
         expect(object_file.valid_image?).to be(false)
       end
@@ -199,7 +199,7 @@ describe Assembly::ObjectFile do
 
     context 'with xml' do
       it 'false' do
-        non_image_file = File.join(Assembly::PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
+        non_image_file = File.join(PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
         object_file = described_class.new(non_image_file)
         expect(object_file.valid_image?).to be(false)
       end
@@ -359,7 +359,7 @@ describe Assembly::ObjectFile do
 
   describe '#file_exists?' do
     it 'false when a valid directory is specified instead of a file' do
-      path = Assembly::PATH_TO_GEM
+      path = PATH_TO_GEM
       object_file = described_class.new(path)
       expect(File.exist?(path)).to be true
       expect(File.directory?(path)).to be true
@@ -367,7 +367,7 @@ describe Assembly::ObjectFile do
     end
 
     it 'false when a non-existent file is specified' do
-      path = File.join(Assembly::PATH_TO_GEM, 'file_not_there.txt')
+      path = File.join(PATH_TO_GEM, 'file_not_there.txt')
       object_file = described_class.new(path)
       expect(File.exist?(path)).to be false
       expect(File.directory?(path)).to be false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,13 +10,10 @@ RSpec.configure do |config|
   config.order = 'random'
 end
 
-TEST_DATA_DIR = File.join(Assembly::PATH_TO_GEM, 'spec', 'test_data')
-TEST_INPUT_DIR       = File.join(TEST_DATA_DIR, 'input')
-TEST_OUTPUT_DIR      = File.join(TEST_DATA_DIR, 'output')
+PATH_TO_GEM = File.expand_path("#{File.dirname(__FILE__)}/..")
+TEST_INPUT_DIR       = File.join(PATH_TO_GEM, 'spec', 'test_data', 'input')
 TEST_TIF_INPUT_FILE  = File.join(TEST_INPUT_DIR, 'test.tif')
-TEST_JPEG_INPUT_FILE = File.join(TEST_INPUT_DIR, 'test.jpg')
 TEST_JP2_INPUT_FILE = File.join(TEST_INPUT_DIR, 'test.jp2')
-TEST_JP2_OUTPUT_FILE = File.join(TEST_OUTPUT_DIR, 'test.jp2')
 
 TEST_TIFF_NO_COLOR_FILE = File.join(TEST_INPUT_DIR, 'test_no_color_profile.tif')
 
@@ -30,5 +27,3 @@ TEST_JSON_FILE = File.join(TEST_INPUT_DIR, 'test.json')
 
 TEST_OBJ_FILE = File.join(TEST_INPUT_DIR, 'someobject.obj')
 TEST_PLY_FILE = File.join(TEST_INPUT_DIR, 'someobject.ply')
-
-TEST_DRUID = 'nx288wh8889'


### PR DESCRIPTION
## Why was this change made? 🤔

- remove unused constants in spec_helper
- move PATH_TO_GEM to spec_helper where it belongs (I did a github search on it and it is used in no other repos (gem consumers))

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



