### PR TITLE
remove unused private method code

### DIFF
--- a/lib/assembly/object_file.rb
+++ b/lib/assembly/object_file.rb
@@ -200,17 +200,5 @@ module Assembly
     def override_mimetype
       @override_mimetype ||= Assembly::OVERRIDE_MIMETYPES.fetch(ext.to_sym, '')
     end
-
-    # @note Uses shell call to "file", only expected to work on unix based systems
-    # @return [String] encoding for supplied file
-    # @example
-    #   source_file = Assembly::ObjectFile.new('/input/path_to_file.txt')
-    #   puts source_file.encoding # 'us-ascii'
-    def encoding
-      @encoding ||= begin
-        check_for_file
-        `file --mime-encoding "#{path}"`.delete("\n").split(':')[1].strip
-      end
-    end
   end
 end

--- a/spec/assembly/object_file_spec.rb
+++ b/spec/assembly/object_file_spec.rb
@@ -387,22 +387,6 @@ describe Assembly::ObjectFile do
     end
   end
 
-  describe '#encoding' do
-    context 'with .tif file' do
-      it 'binary' do
-        object_file = described_class.new(TEST_TIF_INPUT_FILE)
-        expect(object_file.send(:encoding)).to eq('binary')
-      end
-    end
-
-    context 'with .txt file' do
-      it 'binary' do
-        object_file = described_class.new(TEST_RES1_TEXT)
-        expect(object_file.send(:encoding)).to eq('us-ascii')
-      end
-    end
-  end
-
   describe '#exif' do
     it 'returns MiniExiftool object' do
       object_file = described_class.new(TEST_TIF_INPUT_FILE)


### PR DESCRIPTION
## Why was this change made? 🤔

this private method is never used. 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



