### PR TITLE
Don't raise errors if MiniExiftool can't initialize

### DIFF
--- a/lib/assembly/object_file.rb
+++ b/lib/assembly/object_file.rb
@@ -81,12 +81,9 @@ module Assembly
         check_for_file
         MiniExiftool.new(path, replace_invalid_chars: '?')
       rescue MiniExiftool::Error
-        # MiniExiftool will throw an exception when it tries to initialize for problematic files,
-        # but the exception it throws does not tell you the file that caused the problem.
-        # Instead, we will raise our own exception with more context in logging/reporting upstream.
-        # Note: if the file that causes the problem should NOT use exiftool to determine mimetype, add it to the skipped
-        # mimetypes in Assembly::TRUSTED_MIMETYPES to bypass initialization of MiniExiftool for mimetype generation
-        raise MiniExiftool::Error, "error initializing MiniExiftool for #{path}"
+        # MiniExiftool may raise an error on files it doesn't know how to handle (disk images for example)
+        # but we don't want this to prevent an ObjectFile from being created, so just swallow it.
+        nil
       end
     end
 

--- a/spec/assembly/object_file_spec.rb
+++ b/spec/assembly/object_file_spec.rb
@@ -388,16 +388,16 @@ describe Assembly::ObjectFile do
   end
 
   describe '#exif' do
-    it 'returns MiniExiftool object' do
-      object_file = described_class.new(TEST_TIF_INPUT_FILE)
-      expect(object_file.exif).not_to be_nil
-      expect(object_file.exif.class).to eq MiniExiftool
-    end
+    subject(:exif) { object_file.exif }
 
-    it 'raises MiniExiftool::Error with file path if exiftool raises one' do
-      object_file = described_class.new('spec/test_data/empty.txt')
-      expect { object_file.exif }.to raise_error(MiniExiftool::Error,
-                                                 "error initializing MiniExiftool for #{object_file.path}")
+    let(:object_file) { described_class.new(TEST_TIF_INPUT_FILE) }
+
+    it { is_expected.to be_kind_of MiniExiftool }
+
+    context 'when exiftool raises an error initializing the file' do
+      let(:object_file) { described_class.new('spec/test_data/empty.txt') }
+
+      it { is_expected.to be_nil }
     end
   end
 


### PR DESCRIPTION


## Why was this change made? 🤔

Errors were being raised when trying to create a discovery report for iso disk images.

Fixes #95

## How was this change tested? 🤨
test suite

