### PR TITLE
Prevent a targa image from being treated like a real image

### DIFF
--- a/lib/assembly/object_file.rb
+++ b/lib/assembly/object_file.rb
@@ -121,12 +121,17 @@ module Assembly
       lookup.nil? ? :other : lookup.media_type.to_sym
     end
 
-    # @return [Boolean] true if the mime-types gem recognizes it as an image (from file extension lookup)
+    # @return [Boolean] true if the mime-types gem recognizes it as an image
     def image?
-      object_type == :image
+      return false if object_type != :image
+
+      # We exclude TARGA images here because we've seen where the file is a disk image and
+      # when we look for a mime type it is `image/x-tga', however it is not
+      # recognizable by exiftool.  See https://github.com/sul-dlss/assembly-objectfile/issues/98
+      mimetype != 'image/x-tga'
     end
 
-    # @return [Boolean] true if the mime-types gem recognizes it as an image (from file extension lookup)
+    # @return [Boolean] true if the mime-types gem recognizes it as an image
     #   AND it is a jp2 or jp2able?
     def valid_image?
       return false unless image?

--- a/spec/assembly/object_file_spec.rb
+++ b/spec/assembly/object_file_spec.rb
@@ -97,34 +97,41 @@ describe Assembly::ObjectFile do
   end
 
   describe '#image?' do
+    subject { object_file.image? }
+
     context 'with tiff' do
-      it 'true' do
-        object_file = described_class.new(TEST_TIF_INPUT_FILE)
-        expect(object_file.image?).to be(true)
-      end
+      let(:object_file) { described_class.new(TEST_TIF_INPUT_FILE) }
+
+      it { is_expected.to be true }
     end
 
     context 'with jp2' do
-      it 'true' do
-        object_file = described_class.new(TEST_JP2_INPUT_FILE)
-        expect(object_file.image?).to be(true)
+      let(:object_file) { described_class.new(TEST_JP2_INPUT_FILE) }
+
+      it { is_expected.to be true }
+    end
+
+    context 'with targa file' do
+      before do
+        allow(object_file).to receive(:exif_mimetype).and_return(nil)
+        allow(object_file).to receive(:file_mimetype).and_return('image/x-tga')
       end
+
+      let(:object_file) { described_class.new(TEST_JP2_INPUT_FILE) }
+
+      it { is_expected.to be false }
     end
 
     context 'with ruby file' do
-      it 'false' do
-        non_image_file = File.join(PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
-        object_file = described_class.new(non_image_file)
-        expect(object_file.image?).to be(false)
-      end
+      let(:object_file) { described_class.new(File.join(PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')) }
+
+      it { is_expected.to be false }
     end
 
     context 'with xml' do
-      it 'false' do
-        non_image_file = File.join(PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')
-        object_file = described_class.new(non_image_file)
-        expect(object_file.image?).to be(false)
-      end
+      let(:object_file) { described_class.new(File.join(PATH_TO_GEM, 'spec/test_data/input/file_with_no_exif.xml')) }
+
+      it { is_expected.to be false }
     end
   end
 


### PR DESCRIPTION


## Why was this change made? 🤔
This was detected in a disk image, but exiftool could not make any sense of it.

Fixes #98


## How was this change tested? 🤨
ci test

