### PR TITLE
spec_helper: more like other spec_helpers; move vars to spec file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 *.gem
 .DS_Store
 .bundle
-config/certs/*
-config/environments/*
+.rspec_status
 coverage/*
 doc/*
 log/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,9 @@ RSpec/MultipleExpectations:
   Exclude:
     - spec/features/**/*_spec.rb
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 4 # default: 3
 

--- a/spec/assembly/object_file_spec.rb
+++ b/spec/assembly/object_file_spec.rb
@@ -3,6 +3,19 @@
 require 'spec_helper'
 
 describe Assembly::ObjectFile do
+  let(:root_path) { File.expand_path("#{File.dirname(__dir__)}/..") }
+  let(:fixture_input_dir) { File.join(root_path, 'spec', 'fixtures', 'input') }
+  let(:tif_fixture_file) { File.join(fixture_input_dir, 'test.tif') }
+  let(:jp2_fixture_file) { File.join(fixture_input_dir, 'test.jp2') }
+  let(:tiff_no_color_fixture_file) { File.join(fixture_input_dir, 'test_no_color_profile.tif') }
+  let(:resource1_tif_fixture_file) { File.join(fixture_input_dir, 'res1_image1.tif') }
+  let(:resource1_text_fixture_file) { File.join(fixture_input_dir, 'res1_textfile.txt') }
+  let(:resource1_pdf_fixture_file) { File.join(fixture_input_dir, 'res1_transcript.pdf') }
+  let(:no_exif_fixture_file) { File.join(fixture_input_dir, 'file_with_no_exif.xml') }
+  let(:json_fixture_file) { File.join(fixture_input_dir, 'test.json') }
+  let(:obj_fixture_file) { File.join(fixture_input_dir, 'someobject.obj') }
+  let(:ply_fixture_file) { File.join(fixture_input_dir, 'someobject.ply') }
+
   describe '.common_path' do
     context 'when common path is 2 nodes out of 4' do
       it 'returns the common directory' do
@@ -69,29 +82,29 @@ describe Assembly::ObjectFile do
 
   describe '#filename' do
     it 'returns File.basename' do
-      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      object_file = described_class.new(tif_fixture_file)
       expect(object_file.filename).to eq('test.tif')
-      expect(object_file.filename).to eq(File.basename(TEST_TIF_INPUT_FILE))
+      expect(object_file.filename).to eq(File.basename(tif_fixture_file))
     end
   end
 
   describe '#ext' do
     it 'returns the file extension' do
-      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      object_file = described_class.new(tif_fixture_file)
       expect(object_file.ext).to eq('.tif')
     end
   end
 
   describe '#dirname' do
     it 'returns the File.dirname' do
-      object_file = described_class.new(TEST_TIF_INPUT_FILE)
-      expect(object_file.dirname).to eq(File.dirname(TEST_TIF_INPUT_FILE))
+      object_file = described_class.new(tif_fixture_file)
+      expect(object_file.dirname).to eq(File.dirname(tif_fixture_file))
     end
   end
 
   describe '#filename_without_ext' do
     it 'returns filename before extension' do
-      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      object_file = described_class.new(tif_fixture_file)
       expect(object_file.filename_without_ext).to eq('test')
     end
   end
@@ -100,13 +113,13 @@ describe Assembly::ObjectFile do
     subject { object_file.image? }
 
     context 'with tiff' do
-      let(:object_file) { described_class.new(TEST_TIF_INPUT_FILE) }
+      let(:object_file) { described_class.new(tif_fixture_file) }
 
       it { is_expected.to be true }
     end
 
     context 'with jp2' do
-      let(:object_file) { described_class.new(TEST_JP2_INPUT_FILE) }
+      let(:object_file) { described_class.new(jp2_fixture_file) }
 
       it { is_expected.to be true }
     end
@@ -117,19 +130,19 @@ describe Assembly::ObjectFile do
         allow(object_file).to receive(:file_mimetype).and_return('image/x-tga')
       end
 
-      let(:object_file) { described_class.new(TEST_JP2_INPUT_FILE) }
+      let(:object_file) { described_class.new(jp2_fixture_file) }
 
       it { is_expected.to be false }
     end
 
     context 'with ruby file' do
-      let(:object_file) { described_class.new(File.join(PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')) }
+      let(:object_file) { described_class.new(File.join(root_path, 'spec/assembly/object_file_spec.rb')) }
 
       it { is_expected.to be false }
     end
 
     context 'with xml' do
-      let(:object_file) { described_class.new(File.join(TEST_INPUT_DIR, 'file_with_no_exif.xml')) }
+      let(:object_file) { described_class.new(File.join(fixture_input_dir, 'file_with_no_exif.xml')) }
 
       it { is_expected.to be false }
     end
@@ -138,21 +151,21 @@ describe Assembly::ObjectFile do
   describe '#object_type' do
     context 'with tiff' do
       it ':image' do
-        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        object_file = described_class.new(tif_fixture_file)
         expect(object_file.object_type).to eq(:image)
       end
     end
 
     context 'with jp2' do
       it ':image' do
-        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        object_file = described_class.new(jp2_fixture_file)
         expect(object_file.object_type).to eq(:image)
       end
     end
 
     context 'with ruby file' do
       it ':text' do
-        non_image_file = File.join(PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
+        non_image_file = File.join(root_path, 'spec/assembly/object_file_spec.rb')
         object_file = described_class.new(non_image_file)
         expect(object_file.object_type).to eq(:text)
       end
@@ -160,7 +173,7 @@ describe Assembly::ObjectFile do
 
     context 'with xml' do
       it ':application' do
-        non_image_file = File.join(TEST_INPUT_DIR, 'file_with_no_exif.xml')
+        non_image_file = File.join(fixture_input_dir, 'file_with_no_exif.xml')
         object_file = described_class.new(non_image_file)
         expect(object_file.object_type).to eq(:application)
       end
@@ -170,35 +183,35 @@ describe Assembly::ObjectFile do
   describe '#valid_image?' do
     context 'with tiff' do
       it 'true' do
-        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        object_file = described_class.new(tif_fixture_file)
         expect(object_file.valid_image?).to be(true)
       end
     end
 
     context 'with tiff resolution 1' do
       it 'true' do
-        object_file = described_class.new(TEST_RES1_TIF1)
+        object_file = described_class.new(resource1_tif_fixture_file)
         expect(object_file.valid_image?).to be(true)
       end
     end
 
     context 'with tiff no color' do
       it 'true' do
-        object_file = described_class.new(TEST_TIFF_NO_COLOR_FILE)
+        object_file = described_class.new(tiff_no_color_fixture_file)
         expect(object_file.valid_image?).to be(true)
       end
     end
 
     context 'with jp2' do
       it 'true' do
-        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        object_file = described_class.new(jp2_fixture_file)
         expect(object_file.valid_image?).to be(true)
       end
     end
 
     context 'with ruby file' do
       it 'false' do
-        non_image_file = File.join(PATH_TO_GEM, 'spec/assembly/object_file_spec.rb')
+        non_image_file = File.join(root_path, 'spec/assembly/object_file_spec.rb')
         object_file = described_class.new(non_image_file)
         expect(object_file.valid_image?).to be(false)
       end
@@ -206,7 +219,7 @@ describe Assembly::ObjectFile do
 
     context 'with xml' do
       it 'false' do
-        non_image_file = File.join(TEST_INPUT_DIR, 'file_with_no_exif.xml')
+        non_image_file = File.join(fixture_input_dir, 'file_with_no_exif.xml')
         object_file = described_class.new(non_image_file)
         expect(object_file.valid_image?).to be(false)
       end
@@ -217,14 +230,14 @@ describe Assembly::ObjectFile do
     # rubocop:disable RSpec/RepeatedExampleGroupBody
     context 'with .txt file' do
       it 'plain/text' do
-        object_file = described_class.new(TEST_RES1_TEXT)
+        object_file = described_class.new(resource1_text_fixture_file)
         expect(object_file.mimetype).to eq('text/plain')
       end
     end
 
     context 'with .xml file' do
       it 'plain/text' do
-        object_file = described_class.new(TEST_RES1_TEXT)
+        object_file = described_class.new(resource1_text_fixture_file)
         expect(object_file.mimetype).to eq('text/plain')
       end
     end
@@ -232,21 +245,21 @@ describe Assembly::ObjectFile do
 
     context 'with .tif file' do
       it 'image/tiff' do
-        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        object_file = described_class.new(tif_fixture_file)
         expect(object_file.mimetype).to eq('image/tiff')
       end
     end
 
     context 'with .jp2 file' do
       it 'image/jp2' do
-        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        object_file = described_class.new(jp2_fixture_file)
         expect(object_file.mimetype).to eq('image/jp2')
       end
     end
 
     context 'with .pdf file' do
       it 'application/pdf' do
-        object_file = described_class.new(TEST_RES1_PDF)
+        object_file = described_class.new(resource1_pdf_fixture_file)
         expect(object_file.mimetype).to eq('application/pdf')
       end
     end
@@ -254,21 +267,21 @@ describe Assembly::ObjectFile do
     context 'with .obj (3d) file' do
       context 'when default preference (unix file system command)' do
         it 'plain/text' do
-          object_file = described_class.new(TEST_OBJ_FILE)
+          object_file = described_class.new(obj_fixture_file)
           expect(object_file.mimetype).to eq('text/plain')
         end
       end
 
       context 'when mimetype extension gem preferred over unix file system command' do
         it 'application/x-tgif' do
-          object_file = described_class.new(TEST_OBJ_FILE, mime_type_order: %i[extension file exif])
+          object_file = described_class.new(obj_fixture_file, mime_type_order: %i[extension file exif])
           expect(object_file.mimetype).to eq('application/x-tgif')
         end
       end
 
       context 'when invalid first preference mimetype generation' do
         it 'ignores invalid mimetype generation method and respects valid method preference order' do
-          object_file = described_class.new(TEST_OBJ_FILE, mime_type_order: %i[bogus extension file])
+          object_file = described_class.new(obj_fixture_file, mime_type_order: %i[bogus extension file])
           expect(object_file.mimetype).to eq('application/x-tgif')
         end
       end
@@ -276,14 +289,14 @@ describe Assembly::ObjectFile do
 
     context 'with .ply 3d file' do
       it 'text/plain' do
-        object_file = described_class.new(TEST_PLY_FILE)
+        object_file = described_class.new(ply_fixture_file)
         expect(object_file.mimetype).to eq('text/plain')
       end
     end
 
     context 'when exif information is damaged' do
       it 'gives us the mimetype' do
-        object_file = described_class.new(TEST_FILE_NO_EXIF)
+        object_file = described_class.new(no_exif_fixture_file)
         expect(object_file.filename).to eq('file_with_no_exif.xml')
         expect(object_file.ext).to eq('.xml')
         # we could get either of these mimetypes depending on the OS
@@ -293,7 +306,7 @@ describe Assembly::ObjectFile do
 
     context 'when .json file' do
       it 'uses the manual mapping to set the correct mimetype of application/json for a .json file' do
-        object_file = described_class.new(TEST_JSON_FILE)
+        object_file = described_class.new(json_fixture_file)
         expect(object_file.send(:exif_mimetype)).to be_nil # exif
         expect(object_file.send(:file_mimetype)).to eq('text/plain') # unix file system command
         expect(object_file.mimetype).to eq('application/json') # our configured mapping overrides both
@@ -304,14 +317,14 @@ describe Assembly::ObjectFile do
   describe '#file_mimetype (unix file system command)' do
     context 'when .json file' do
       it 'text/plain' do
-        object_file = described_class.new(TEST_JSON_FILE)
+        object_file = described_class.new(json_fixture_file)
         expect(object_file.send(:file_mimetype)).to eq('text/plain')
       end
     end
 
     context 'when .tif file' do
       it 'image/tiff' do
-        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        object_file = described_class.new(tif_fixture_file)
         expect(object_file.send(:file_mimetype)).to eq('image/tiff')
       end
     end
@@ -320,21 +333,21 @@ describe Assembly::ObjectFile do
   describe '#jp2able?' do
     context 'with jp2 file' do
       it 'false' do
-        object_file = described_class.new(TEST_JP2_INPUT_FILE)
+        object_file = described_class.new(jp2_fixture_file)
         expect(object_file.jp2able?).to be(false)
       end
     end
 
     context 'with tiff resolution 1 file' do
       it 'true' do
-        object_file = described_class.new(TEST_RES1_TIF1)
+        object_file = described_class.new(resource1_tif_fixture_file)
         expect(object_file.jp2able?).to be(true)
       end
     end
 
     context 'with tiff no color file' do
       it 'true' do
-        object_file = described_class.new(TEST_TIFF_NO_COLOR_FILE)
+        object_file = described_class.new(tiff_no_color_fixture_file)
         expect(object_file.jp2able?).to be(true)
       end
     end
@@ -342,7 +355,7 @@ describe Assembly::ObjectFile do
 
   describe '#md5' do
     it 'computes md5 for an image file' do
-      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      object_file = described_class.new(tif_fixture_file)
       expect(object_file.md5).to eq('a2400500acf21e43f5440d93be894101')
     end
 
@@ -354,7 +367,7 @@ describe Assembly::ObjectFile do
 
   describe '#sha1' do
     it 'computes sha1 for an image file' do
-      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      object_file = described_class.new(tif_fixture_file)
       expect(object_file.sha1).to eq('8d11fab63089a24c8b17063d29a4b0eac359fb41')
     end
 
@@ -366,7 +379,7 @@ describe Assembly::ObjectFile do
 
   describe '#file_exists?' do
     it 'false when a valid directory is specified instead of a file' do
-      path = PATH_TO_GEM
+      path = root_path
       object_file = described_class.new(path)
       expect(File.exist?(path)).to be true
       expect(File.directory?(path)).to be true
@@ -374,7 +387,7 @@ describe Assembly::ObjectFile do
     end
 
     it 'false when a non-existent file is specified' do
-      path = File.join(PATH_TO_GEM, 'file_not_there.txt')
+      path = File.join(root_path, 'file_not_there.txt')
       object_file = described_class.new(path)
       expect(File.exist?(path)).to be false
       expect(File.directory?(path)).to be false
@@ -384,7 +397,7 @@ describe Assembly::ObjectFile do
 
   describe '#filesize' do
     it 'tells us the size of an input file' do
-      object_file = described_class.new(TEST_TIF_INPUT_FILE)
+      object_file = described_class.new(tif_fixture_file)
       expect(object_file.filesize).to eq(63_542)
     end
 
@@ -397,7 +410,7 @@ describe Assembly::ObjectFile do
   describe '#exif' do
     subject(:exif) { object_file.exif }
 
-    let(:object_file) { described_class.new(TEST_TIF_INPUT_FILE) }
+    let(:object_file) { described_class.new(tif_fixture_file) }
 
     it { is_expected.to be_a MiniExiftool }
 
@@ -412,14 +425,14 @@ describe Assembly::ObjectFile do
     # mime-types gem, based on a file extension lookup
     context 'with .obj file' do
       it 'application/x-tgif' do
-        object_file = described_class.new(TEST_OBJ_FILE)
+        object_file = described_class.new(obj_fixture_file)
         expect(object_file.send(:extension_mimetype)).to eq('application/x-tgif')
       end
     end
 
     context 'with .tif file' do
       it 'image/tiff' do
-        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        object_file = described_class.new(tif_fixture_file)
         expect(object_file.send(:extension_mimetype)).to eq('image/tiff')
       end
     end
@@ -428,14 +441,14 @@ describe Assembly::ObjectFile do
   describe '#exif_mimetype' do
     context 'with .tif file' do
       it 'image/tiff' do
-        object_file = described_class.new(TEST_TIF_INPUT_FILE)
+        object_file = described_class.new(tif_fixture_file)
         expect(object_file.send(:exif_mimetype)).to eq('image/tiff')
       end
     end
 
     context 'when .json file' do
       it 'nil' do
-        object_file = described_class.new(TEST_JSON_FILE)
+        object_file = described_class.new(json_fixture_file)
         expect(object_file.send(:exif_mimetype)).to be_nil
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,23 +7,15 @@ require File.expand_path("#{File.dirname(__FILE__)}/../config/boot")
 require 'pry-byebug'
 
 RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  config.default_formatter = 'doc' if config.files_to_run.one?
+
   config.order = 'random'
+  Kernel.srand config.seed
 end
-
-PATH_TO_GEM = File.expand_path("#{File.dirname(__FILE__)}/..")
-TEST_INPUT_DIR       = File.join(PATH_TO_GEM, 'spec', 'fixtures', 'input')
-TEST_TIF_INPUT_FILE  = File.join(TEST_INPUT_DIR, 'test.tif')
-TEST_JP2_INPUT_FILE = File.join(TEST_INPUT_DIR, 'test.jp2')
-
-TEST_TIFF_NO_COLOR_FILE = File.join(TEST_INPUT_DIR, 'test_no_color_profile.tif')
-
-TEST_RES1_TIF1 = File.join(TEST_INPUT_DIR, 'res1_image1.tif')
-TEST_RES1_TEXT = File.join(TEST_INPUT_DIR, 'res1_textfile.txt')
-TEST_RES1_PDF = File.join(TEST_INPUT_DIR, 'res1_transcript.pdf')
-
-TEST_FILE_NO_EXIF = File.join(TEST_INPUT_DIR, 'file_with_no_exif.xml')
-
-TEST_JSON_FILE = File.join(TEST_INPUT_DIR, 'test.json')
-
-TEST_OBJ_FILE = File.join(TEST_INPUT_DIR, 'someobject.obj')
-TEST_PLY_FILE = File.join(TEST_INPUT_DIR, 'someobject.ply')


### PR DESCRIPTION
## Why was this change made? 🤔

reduce maint costs by making specs more like specs elsewhere.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



