### PR TITLE
remove provider_sha1 param as it is never used (by consumers)

### DIFF
--- a/lib/assembly/object_file.rb
+++ b/lib/assembly/object_file.rb
@@ -27,7 +27,7 @@ module Assembly
       end
     end
 
-    attr_accessor :file_attributes, :label, :path, :provider_md5, :provider_sha1, :relative_path, :mime_type_order
+    attr_accessor :file_attributes, :label, :path, :provider_md5, :relative_path, :mime_type_order
 
     VALID_MIMETYPE_METHODS = %i[override exif file extension].freeze
 
@@ -39,7 +39,6 @@ module Assembly
     # @option params [String] :label a resource label (files bundled together will just get the first
     #                                file's label attribute if set)
     # @option params [String] :provider_md5 pre-computed MD5 checksum
-    # @option params [String] :provider_sha1 pre-computed SHA1 checksum
     # @option params [String] :relative_path if you want the file ids in the content metadata it can be set,
     #                                        otherwise content metadata will get the full path
     # @option params [Array] :mime_type_order can be set to the order in which you want mimetypes to be determined
@@ -55,7 +54,6 @@ module Assembly
       @file_attributes = params[:file_attributes]
       @relative_path = params[:relative_path]
       @provider_md5 = params[:provider_md5]
-      @provider_sha1 = params[:provider_sha1]
       @mime_type_order = params[:mime_type_order] || default_mime_type_order
     end
 

--- a/spec/assembly/object_file_spec.rb
+++ b/spec/assembly/object_file_spec.rb
@@ -46,7 +46,6 @@ describe Assembly::ObjectFile do
         expect(object_file.path).to eq('/some/file.txt')
         expect(object_file.label).to be_nil
         expect(object_file.file_attributes).to be_nil
-        expect(object_file.provider_sha1).to be_nil
         expect(object_file.provider_md5).to be_nil
         expect(object_file.relative_path).to be_nil
       end
@@ -65,7 +64,6 @@ describe Assembly::ObjectFile do
         expect(object_file.path).to eq('/some/file.txt')
         expect(object_file.label).to eq('some label')
         expect(object_file.file_attributes).to eq('shelve' => 'yes', 'publish' => 'yes', 'preserve' => 'no')
-        expect(object_file.provider_sha1).to be_nil
         expect(object_file.provider_md5).to be_nil
         expect(object_file.relative_path).to eq('/tmp')
       end


### PR DESCRIPTION
## Why was this change made? 🤔

`provider_sha1` param was never used -- the only usage in this repo is in specs just checking if the param is set when it was passed in.

I looked for `provider_sha1` in all the consumers for this gem, and the only occurrence was in preassembly which delegated it to this gem.  See PR sul-dlss/pre-assembly/pull/1105.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



