### PR TITLE
Patch digests to use thread-safe syntax

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assembly-objectfile (2.1.3)
+    assembly-objectfile (2.1.4)
       activesupport (>= 5.2.0)
       mime-types (> 3)
       mini_exiftool
@@ -100,4 +100,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.17
+   2.4.13

--- a/lib/assembly/object_file.rb
+++ b/lib/assembly/object_file.rb
@@ -88,13 +88,13 @@ module Assembly
     # @return [String] computed md5 checksum
     def md5
       check_for_file unless @md5
-      @md5 ||= Digest::MD5.file(path).hexdigest
+      @md5 ||= Digest(:MD5).file(path).hexdigest
     end
 
     # @return [String] computed sha1 checksum
     def sha1
       check_for_file unless @sha1
-      @sha1 ||= Digest::SHA1.file(path).hexdigest
+      @sha1 ||= Digest(:SHA1).file(path).hexdigest
     end
 
     # Returns mimetype information for the current file based on the ordering set in default_mime_type_order

--- a/lib/assembly/object_file/version.rb
+++ b/lib/assembly/object_file/version.rb
@@ -4,6 +4,6 @@
 module Assembly
   class ObjectFile
     # Gem version
-    VERSION = '2.1.3'
+    VERSION = '2.1.4'
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

This commit patches a bug with thread-safety that causes an exception under Ruby 3.2. See https://app.honeybadger.io/projects/52899/faults/95866921.

And bumps the version a patch level.

## How was this change tested? 🤨

CI and will be tested in deployed envs (in gis-robot-suite)
