### PR TITLE
.vtt files should be text/vtt

### DIFF
--- a/lib/assembly-objectfile.rb
+++ b/lib/assembly-objectfile.rb
@@ -18,7 +18,8 @@ module Assembly
   # the unix file system command returns the mapping format is "extension with period: returned mimetype",
   # e.g. for any .json file, you will always get `application/json`
   OVERRIDE_MIMETYPES = {
-    '.json': 'application/json'
+    '.json': 'application/json',
+    '.vtt': 'text/vtt'
   }.freeze
 end
 

--- a/spec/assembly/object_file_spec.rb
+++ b/spec/assembly/object_file_spec.rb
@@ -15,6 +15,7 @@ describe Assembly::ObjectFile do
   let(:json_fixture_file) { File.join(fixture_input_dir, 'test.json') }
   let(:obj_fixture_file) { File.join(fixture_input_dir, 'someobject.obj') }
   let(:ply_fixture_file) { File.join(fixture_input_dir, 'someobject.ply') }
+  let(:vtt_fixture_file) { File.join(fixture_input_dir, 'test.vtt') }
 
   describe '.common_path' do
     context 'when common path is 2 nodes out of 4' do
@@ -310,6 +311,15 @@ describe Assembly::ObjectFile do
         expect(object_file.mimetype).to eq('application/json') # our configured mapping overrides both
       end
     end
+
+    context 'when .vtt file' do
+      it 'uses the manual mapping to set the correct mimetype of text/vtt for a .vtt file' do
+        object_file = described_class.new(vtt_fixture_file)
+        expect(object_file.send(:exif_mimetype)).to be_nil # exif
+        expect(object_file.send(:file_mimetype)).to eq('text/plain') # unix file system command
+        expect(object_file.mimetype).to eq('text/vtt') # our configured mapping overrides both
+      end
+    end
   end
 
   describe '#file_mimetype (unix file system command)' do
@@ -434,6 +444,13 @@ describe Assembly::ObjectFile do
         expect(object_file.send(:extension_mimetype)).to eq('image/tiff')
       end
     end
+
+    context 'with .vtt file' do
+      it 'text/plain' do
+        object_file = described_class.new(vtt_fixture_file)
+        expect(object_file.send(:extension_mimetype)).to eq('text/vtt')
+      end
+    end
   end
 
   describe '#exif_mimetype' do
@@ -447,6 +464,13 @@ describe Assembly::ObjectFile do
     context 'when .json file' do
       it 'nil' do
         object_file = described_class.new(json_fixture_file)
+        expect(object_file.send(:exif_mimetype)).to be_nil
+      end
+    end
+
+    context 'when .vtt file' do
+      it 'nil' do
+        object_file = described_class.new(vtt_fixture_file)
         expect(object_file.send(:exif_mimetype)).to be_nil
       end
     end

--- a/spec/fixtures/input/test.vtt
+++ b/spec/fixtures/input/test.vtt
@@ -1,0 +1,1504 @@
+WEBVTT
+Kind: captions
+Language: en
+
+00:00:05.080 --> 00:00:10.200
+When I first received this Nobel Prize for
+Literature, I got to wondering exactly how
+
+00:00:10.200 --> 00:00:14.030
+my songs related to literature.
+
+00:00:14.030 --> 00:00:17.340
+I wanted to reflect on it and see where the
+connection was.
+
+00:00:17.340 --> 00:00:20.519
+I'm going to try to articulate that to you.
+
+00:00:20.519 --> 00:00:26.380
+And most likely it will go in a roundabout
+way, but I hope what I say will be worthwhile
+
+00:00:26.380 --> 00:00:27.380
+and purposeful.
+
+00:00:27.380 --> 00:00:35.489
+If I was to go back to the dawning of it all,
+I guess I'd have to start with Buddy Holly.
+
+00:00:35.489 --> 00:00:40.050
+Buddy died when I was about eighteen and he
+was twenty-two.
+
+00:00:40.050 --> 00:00:43.250
+From the moment I first heard him, I felt
+akin.
+
+00:00:43.250 --> 00:00:46.550
+I felt related, like he was an older brother.
+
+00:00:46.550 --> 00:00:49.649
+I even thought I resembled him.
+
+00:00:49.649 --> 00:00:55.610
+Buddy played the music that I loved - the
+music I grew up on: country western, rock
+
+00:00:55.610 --> 00:00:58.450
+'n' roll, and rhythm and blues.
+
+00:00:58.450 --> 00:01:04.330
+Three separate strands of music that he intertwined
+and infused into one genre.
+
+00:01:04.330 --> 00:01:05.810
+One brand.
+
+00:01:05.810 --> 00:01:11.350
+And Buddy wrote songs - songs that had beautiful
+melodies and imaginative verses.
+
+00:01:11.350 --> 00:01:16.070
+And he sang great - sang in more than a few
+voices.
+
+00:01:16.070 --> 00:01:17.880
+He was the archetype.
+
+00:01:17.880 --> 00:01:19.390
+Everything I wasn't and wanted to be.
+
+00:01:19.390 --> 00:01:24.000
+I saw him only but once, and that was a few
+days before he was gone.
+
+00:01:24.000 --> 00:01:29.370
+I had to travel a hundred miles to get to
+see him play, and I wasn't disappointed.
+
+00:01:29.370 --> 00:01:33.740
+He was powerful and electrifying and had a
+commanding presence.
+
+00:01:33.740 --> 00:01:35.549
+I was only six feet away.
+
+00:01:35.549 --> 00:01:36.610
+He was mesmerizing.
+
+00:01:36.610 --> 00:01:42.371
+I watched his face, his hands, the way he
+tapped his foot, his big black glasses, the
+
+00:01:42.371 --> 00:01:48.010
+eyes behind the glasses, the way he held his
+guitar, the way he stood, his neat suit.
+
+00:01:48.010 --> 00:01:49.259
+Everything about him.
+
+00:01:49.259 --> 00:01:51.509
+He looked older than twenty-two.
+
+00:01:51.509 --> 00:01:54.770
+Something about him seemed permanent, and
+he filled me with conviction.
+
+00:01:54.770 --> 00:01:59.049
+Then, out of the blue, the most uncanny thing
+happened.
+
+00:01:59.049 --> 00:02:03.689
+He looked me right straight dead in the eye,
+and he transmitted something.
+
+00:02:03.689 --> 00:02:04.689
+Something I didn't know what.
+
+00:02:04.689 --> 00:02:07.340
+And it gave me the chills.
+
+00:02:07.340 --> 00:02:11.090
+I think it was a day or two after that that
+his plane went down.
+
+00:02:11.090 --> 00:02:15.389
+And somebody - somebody I'd never seen before
+- handed me a Leadbelly record with the song
+
+00:02:15.389 --> 00:02:16.870
+"Cottonfields" on it.
+
+00:02:16.870 --> 00:02:20.170
+And that record changed my life right then
+and there.
+
+00:02:20.170 --> 00:02:22.900
+Transported me into a world I'd never known.
+
+00:02:22.900 --> 00:02:24.749
+It was like an explosion went off.
+
+00:02:24.749 --> 00:02:28.680
+Like I'd been walking in darkness and all
+of the sudden the darkness was illuminated.
+
+00:02:28.680 --> 00:02:30.909
+It was like somebody laid hands on me.
+
+00:02:30.909 --> 00:02:34.969
+I must have played that record a hundred times.
+
+00:02:34.969 --> 00:02:39.620
+It was on a label I'd never heard of with
+a booklet inside with advertisements for other
+
+00:02:39.620 --> 00:02:46.269
+artists on the label: Sonny Terry and Brownie
+McGhee, the New Lost City Ramblers, Jean Ritchie,
+
+00:02:46.269 --> 00:02:47.269
+string bands.
+
+00:02:47.269 --> 00:02:48.540
+I'd never heard of any of them.
+
+00:02:48.540 --> 00:02:53.889
+But I reckoned if they were on this label
+with Leadbelly, they had to be good, so I
+
+00:02:53.889 --> 00:02:55.209
+needed to hear them.
+
+00:02:55.209 --> 00:02:59.139
+I wanted to know all about it and play that
+kind of music.
+
+00:02:59.139 --> 00:03:04.040
+I still had a feeling for the music I'd grown
+up with, but for right now, I forgot about
+
+00:03:04.040 --> 00:03:05.040
+it.
+
+00:03:05.040 --> 00:03:06.040
+Didn't even think about it.
+
+00:03:06.040 --> 00:03:09.629
+For the time being, it was long gone.
+
+00:03:09.629 --> 00:03:12.160
+I hadn't left home yet, but I couldn't wait
+to.
+
+00:03:12.160 --> 00:03:16.519
+I wanted to learn this music and meet the
+people who played it.
+
+00:03:16.519 --> 00:03:20.709
+Eventually, I did leave, and I did learn to
+play those songs.
+
+00:03:20.709 --> 00:03:25.359
+They were different than the radio songs that
+I'd been listening to all along.
+
+00:03:25.359 --> 00:03:27.339
+They were more vibrant and truthful to life.
+
+00:03:27.339 --> 00:03:32.989
+With radio songs, a performer might get a
+hit with a roll of the dice or a fall of the
+
+00:03:32.989 --> 00:03:36.370
+cards, but that didn't matter in the folk
+world.
+
+00:03:36.370 --> 00:03:37.370
+Everything was a hit.
+
+00:03:37.370 --> 00:03:40.519
+All you had to do was be well versed and be
+able to play the melody.
+
+00:03:40.519 --> 00:03:43.810
+Some of these songs were easy, some not.
+
+00:03:43.810 --> 00:03:49.459
+I had a natural feeling for the ancient ballads
+and country blues, but everything else I had
+
+00:03:49.459 --> 00:03:51.209
+to learn from scratch.
+
+00:03:51.209 --> 00:03:56.219
+I was playing for small crowds, sometimes
+no more than four or five people in a room
+
+00:03:56.219 --> 00:03:57.689
+or on a street corner.
+
+00:03:57.689 --> 00:04:03.639
+You had to have a wide repertoire, and you
+had to know what to play and when.
+
+00:04:03.639 --> 00:04:07.040
+Some songs were intimate, some you had to
+shout to be heard.
+
+00:04:07.040 --> 00:04:12.629
+By listening to all the early folk artists
+and singing the songs yourself, you pick up
+
+00:04:12.629 --> 00:04:13.920
+the vernacular.
+
+00:04:13.920 --> 00:04:15.340
+You internalize it.
+
+00:04:15.340 --> 00:04:21.479
+You sing it in the ragtime blues, work songs,
+Georgia sea shanties, Appalachian ballads
+
+00:04:21.479 --> 00:04:23.090
+and cowboy songs.
+
+00:04:23.090 --> 00:04:26.860
+You hear all the finer points, and you learn
+the details.
+
+00:04:26.860 --> 00:04:28.470
+You know what it's all about.
+
+00:04:28.470 --> 00:04:31.340
+Takin' the pistol out and puttin' it back
+in your pocket.
+
+00:04:31.340 --> 00:04:34.509
+Whippin' your way through traffic, talkin'
+in the dark.
+
+00:04:34.509 --> 00:04:38.370
+You know that Stagger Lee was a bad man and
+that Frankie was a good girl.
+
+00:04:38.370 --> 00:04:42.069
+You know that Washington is a bourgeois town
+and you've heard the deep-pitched voice of
+
+00:04:42.069 --> 00:04:46.110
+John the Revelator and you saw the Titanic
+sink in a boggy creek.
+
+00:04:46.110 --> 00:04:50.430
+And you're pals with the wild Irish rover
+and the wild colonial boy.
+
+00:04:50.430 --> 00:04:53.789
+You heard the muffled drums and the fifes
+that played lowly.
+
+00:04:53.789 --> 00:04:59.159
+You've seen the lusty Lord Donald stick a
+knife in his wife, and a lot of your comrades
+
+00:04:59.159 --> 00:05:02.080
+have been wrapped in white linen.
+
+00:05:02.080 --> 00:05:03.949
+I had all the vernacular down.
+
+00:05:03.949 --> 00:05:05.400
+I knew the rhetoric.
+
+00:05:05.400 --> 00:05:10.270
+None of it went over my head - the devices,
+the techniques, the secrets, the mysteries
+
+00:05:10.270 --> 00:05:14.000
+- and I knew all the deserted roads that it
+traveled on, too.
+
+00:05:14.000 --> 00:05:18.820
+I could make it all connect and move with
+the current of the day.
+
+00:05:18.820 --> 00:05:24.479
+When I started writing my own songs, the folk
+lingo was the only vocabulary that I knew,
+
+00:05:24.479 --> 00:05:27.800
+and I used it.
+
+00:05:27.800 --> 00:05:29.560
+But I had something else as well.
+
+00:05:29.560 --> 00:05:34.300
+I had principles and sensibilities and an
+informed view of the world.
+
+00:05:34.300 --> 00:05:36.539
+And I had had that for a while.
+
+00:05:36.539 --> 00:05:38.090
+Learned it all in grammar school.
+
+00:05:38.090 --> 00:05:45.239
+Don Quixote, Ivanhoe, Robinson Crusoe, Gulliver's
+Travels, Tale of Two Cities, all the rest
+
+00:05:45.239 --> 00:05:51.009
+- typical grammar school reading that gave
+you a way of looking at life, an understanding
+
+00:05:51.009 --> 00:05:54.460
+of human nature, and a standard to measure
+things by.
+
+00:05:54.460 --> 00:05:58.439
+I took all that with me when I started composing
+lyrics.
+
+00:05:58.439 --> 00:06:03.599
+And the themes from those books worked their
+way into many of my songs, either knowingly
+
+00:06:03.599 --> 00:06:05.620
+or unintentionally.
+
+00:06:05.620 --> 00:06:12.610
+I wanted to write songs unlike anything anybody
+ever heard, and these themes were fundamental.
+
+00:06:12.610 --> 00:06:17.490
+Specific books that have stuck with me ever
+since I read them way back in grammar school
+
+00:06:17.490 --> 00:06:22.389
+- I want to tell you about three of them:
+Moby Dick, All Quiet on the Western Front
+
+00:06:22.389 --> 00:06:27.219
+and The Odyssey.
+
+00:06:27.219 --> 00:06:33.289
+Moby Dick is a fascinating book, a book that's
+filled with scenes of high drama and dramatic
+
+00:06:33.289 --> 00:06:34.979
+dialogue.
+
+00:06:34.979 --> 00:06:37.300
+The book makes demands on you.
+
+00:06:37.300 --> 00:06:38.740
+The plot is straightforward.
+
+00:06:38.740 --> 00:06:45.080
+The mysterious Captain Ahab - captain of a
+ship called the Pequod - an egomaniac with
+
+00:06:45.080 --> 00:06:51.020
+a peg leg pursuing his nemesis, the great
+white whale Moby Dick who took his leg.
+
+00:06:51.020 --> 00:06:56.490
+And he pursues him all the way from the Atlantic
+around the tip of Africa and into the Indian
+
+00:06:56.490 --> 00:06:57.590
+Ocean.
+
+00:06:57.590 --> 00:07:00.740
+He pursues the whale around both sides of
+the earth.
+
+00:07:00.740 --> 00:07:04.930
+It's an abstract goal, nothing concrete or
+definite.
+
+00:07:04.930 --> 00:07:08.660
+He calls Moby the emperor, sees him as the
+embodiment of evil.
+
+00:07:08.660 --> 00:07:15.449
+Ahab's got a wife and child back in Nantucket
+that he reminisces about now and again.
+
+00:07:15.449 --> 00:07:18.069
+You can anticipate what will happen.
+
+00:07:18.069 --> 00:07:23.370
+The ship's crew is made up of men of different
+races, and any one of them who sights the
+
+00:07:23.370 --> 00:07:26.930
+whale will be given the reward of a gold coin.
+
+00:07:26.930 --> 00:07:32.569
+A lot of Zodiac symbols, religious allegory,
+stereotypes.
+
+00:07:32.569 --> 00:07:38.199
+Ahab encounters other whaling vessels, presses
+the captains for details about Moby.
+
+00:07:38.199 --> 00:07:39.710
+Have they seen him?
+
+00:07:39.710 --> 00:07:45.610
+There's a crazy prophet, Gabriel, on one of
+the vessels, and he predicts Ahab's doom.
+
+00:07:45.610 --> 00:07:51.240
+Says Moby is the incarnate of a Shaker god,
+and that any dealings with him will lead to
+
+00:07:51.240 --> 00:07:52.240
+disaster.
+
+00:07:52.240 --> 00:07:54.900
+He says that to Captain Ahab.
+
+00:07:54.900 --> 00:07:58.419
+Another ship's captain - Captain Boomer - he
+lost an arm to Moby.
+
+00:07:58.419 --> 00:08:01.740
+But he tolerates that, and he's happy to have
+survived.
+
+00:08:01.740 --> 00:08:05.710
+He can't accept Ahab's lust for vengeance.
+
+00:08:05.710 --> 00:08:10.740
+This book tells how different men react in
+different ways to the same experience.
+
+00:08:10.740 --> 00:08:19.050
+A lot of Old Testament, biblical allegory:
+Gabriel, Rachel, Jeroboam, Bildah, Elijah.
+
+00:08:19.050 --> 00:08:28.219
+Pagan names as well: Tashtego, Flask, Daggoo,
+Fleece, Starbuck, Stubb, Martha's Vineyard.
+
+00:08:28.219 --> 00:08:30.650
+The Pagans are idol worshippers.
+
+00:08:30.650 --> 00:08:34.289
+Some worship little wax figures, some wooden
+figures.
+
+00:08:34.289 --> 00:08:35.870
+Some worship fire.
+
+00:08:35.870 --> 00:08:40.130
+The Pequod is the name of an Indian tribe.
+
+00:08:40.130 --> 00:08:42.159
+Moby Dick is a seafaring tale.
+
+00:08:42.159 --> 00:08:46.610
+One of the men, the narrator, says, "Call
+me Ishmael."
+
+00:08:46.610 --> 00:08:50.630
+Somebody asks him where he's from, and he
+says, "It's not down on any map.
+
+00:08:50.630 --> 00:08:53.300
+True places never are."
+
+00:08:53.300 --> 00:08:58.880
+Stubb gives no significance to anything, says
+everything is predestined.
+
+00:08:58.880 --> 00:09:01.800
+Ishmael's been on a sailing ship his entire
+life.
+
+00:09:01.800 --> 00:09:04.680
+Calls the sailing ships his Harvard and Yale.
+
+00:09:04.680 --> 00:09:06.420
+He keeps his distance from people.
+
+00:09:06.420 --> 00:09:09.380
+A typhoon hits the Pequod.
+
+00:09:09.380 --> 00:09:11.420
+Captain Ahab thinks it's a good omen.
+
+00:09:11.420 --> 00:09:14.910
+Starbuck thinks it's a bad omen, considers
+killing Ahab.
+
+00:09:14.910 --> 00:09:20.670
+As soon as the storm ends, a crewmember falls
+from the ship's mast and drowns, foreshadowing
+
+00:09:20.670 --> 00:09:22.840
+what's to come.
+
+00:09:22.840 --> 00:09:29.630
+A Quaker pacifist priest, who is actually
+a bloodthirsty businessman, tells Flask, "Some
+
+00:09:29.630 --> 00:09:34.270
+men who receive injuries are led to God, others
+are led to bitterness."
+
+00:09:34.270 --> 00:09:36.940
+Everything is mixed in.
+
+00:09:36.940 --> 00:09:44.240
+All the myths: the Judeo Christian bible,
+Hindu myths, British legends, Saint George,
+
+00:09:44.240 --> 00:09:47.510
+Perseus, Hercules - they're all whalers.
+
+00:09:47.510 --> 00:09:51.570
+Greek mythology, the gory business of cutting
+up a whale.
+
+00:09:51.570 --> 00:09:58.129
+Lots of facts in this book, geographical knowledge,
+whale oil - good for coronation of royalty
+
+00:09:58.129 --> 00:10:01.449
+- noble families in the whaling industry.
+
+00:10:01.449 --> 00:10:05.350
+Whale oil is used to anoint the kings.
+
+00:10:05.350 --> 00:10:12.990
+History of the whale, phrenology, classical
+philosophy, pseudo-scientific theories, justification
+
+00:10:12.990 --> 00:10:18.769
+for discrimination - everything thrown in
+and none of it hardly rational.
+
+00:10:18.769 --> 00:10:24.360
+Highbrow, lowbrow, chasing illusion, chasing
+death, the great white whale, white as polar
+
+00:10:24.360 --> 00:10:30.110
+bear, white as a white man, the emperor, the
+nemesis, the embodiment of evil.
+
+00:10:30.110 --> 00:10:36.060
+The demented captain who actually lost his
+leg years ago trying to attack Moby with a
+
+00:10:36.060 --> 00:10:37.060
+knife.
+
+00:10:37.060 --> 00:10:39.040
+We see only the surface of things.
+
+00:10:39.040 --> 00:10:42.850
+We can interpret what lies below any way we
+see fit.
+
+00:10:42.850 --> 00:10:48.230
+Crewmen walk around on deck listening for
+mermaids, and sharks and vultures follow the
+
+00:10:48.230 --> 00:10:49.230
+ship.
+
+00:10:49.230 --> 00:10:51.089
+Reading skulls and faces like you read a book.
+
+00:10:51.089 --> 00:10:52.199
+Here's a face.
+
+00:10:52.199 --> 00:10:54.660
+I'll put it in front of you.
+
+00:10:54.660 --> 00:10:56.351
+Read it if you can.
+
+00:10:56.351 --> 00:10:58.160
+Tashtego says that he died and was reborn.
+
+00:10:58.160 --> 00:11:00.820
+His extra days are a gift.
+
+00:11:00.820 --> 00:11:05.850
+He wasn't saved by Christ, though, he says
+he was saved by a fellow man and a non-Christian
+
+00:11:05.850 --> 00:11:07.029
+at that.
+
+00:11:07.029 --> 00:11:08.910
+He parodies the resurrection.
+
+00:11:08.910 --> 00:11:14.870
+When Starbuck tells Ahab that he should let
+bygones be bygones, the angry captain snaps
+
+00:11:14.870 --> 00:11:20.699
+back, "Speak not to me of blasphemy, man,
+I'd strike the sun if it insulted me."
+
+00:11:20.699 --> 00:11:24.529
+Ahab, too, is a poet of eloquence.
+
+00:11:24.529 --> 00:11:30.079
+He says, "The path to my fixed purpose is
+laid with iron rails whereon my soul is grooved
+
+00:11:30.079 --> 00:11:31.079
+to run."
+
+00:11:31.079 --> 00:11:36.790
+Or these lines, "All visible objects are but
+pasteboard masks."
+
+00:11:36.790 --> 00:11:40.310
+Quotable poetic phrases that can't be beat.
+
+00:11:40.310 --> 00:11:44.199
+Finally, Ahab spots Moby, and the harpoons
+come out.
+
+00:11:44.199 --> 00:11:45.850
+Boats are lowered.
+
+00:11:45.850 --> 00:11:49.340
+Ahab's harpoon has been baptized in blood.
+
+00:11:49.340 --> 00:11:52.000
+Moby attacks Ahab's boat and destroys it.
+
+00:11:52.000 --> 00:11:54.870
+Next day, he sights Moby again.
+
+00:11:54.870 --> 00:11:56.329
+Boats are lowered again.
+
+00:11:56.329 --> 00:11:58.509
+Moby attacks Ahab's boat again.
+
+00:11:58.509 --> 00:12:01.910
+On the third day, another boat goes in.
+
+00:12:01.910 --> 00:12:03.490
+More religious allegory.
+
+00:12:03.490 --> 00:12:05.100
+He has risen.
+
+00:12:05.100 --> 00:12:09.199
+Moby attacks one more time, ramming the Pequod
+and sinking it.
+
+00:12:09.199 --> 00:12:13.860
+Ahab gets tangled up in the harpoon lines
+and is thrown out of his boat into a watery
+
+00:12:13.860 --> 00:12:14.860
+grave.
+
+00:12:14.860 --> 00:12:16.579
+Ishmael survives.
+
+00:12:16.579 --> 00:12:19.199
+He's in the sea floating on a coffin.
+
+00:12:19.199 --> 00:12:20.800
+And that's about it.
+
+00:12:20.800 --> 00:12:22.910
+That's the whole story.
+
+00:12:22.910 --> 00:12:31.850
+That theme and all that it implies would work
+its way into more than a few of my songs.
+
+00:12:31.850 --> 00:12:36.470
+All Quiet on the Western Front was another
+book that did.
+
+00:12:36.470 --> 00:12:39.709
+All Quiet on the Western Front is a horror
+story.
+
+00:12:39.709 --> 00:12:45.380
+This is a book where you lose your childhood,
+your faith in a meaningful world, and your
+
+00:12:45.380 --> 00:12:48.360
+concern for individuals.
+
+00:12:48.360 --> 00:12:50.270
+You're stuck in a nightmare.
+
+00:12:50.270 --> 00:12:54.260
+Sucked up into a mysterious whirlpool of death
+and pain.
+
+00:12:54.260 --> 00:12:57.529
+You're defending yourself from elimination.
+
+00:12:57.529 --> 00:13:00.740
+You're being wiped off the face of the map.
+
+00:13:00.740 --> 00:13:08.040
+Once upon a time you were an innocent youth
+with big dreams about being a concert pianist.
+
+00:13:08.040 --> 00:13:14.230
+Once you loved life and the world, and now
+you're shooting it to pieces.
+
+00:13:14.230 --> 00:13:19.279
+Day after day, the hornets bite you and worms
+lap your blood.
+
+00:13:19.279 --> 00:13:20.480
+You're a cornered animal.
+
+00:13:20.480 --> 00:13:22.870
+You don't fit anywhere.
+
+00:13:22.870 --> 00:13:25.339
+The falling rain is monotonous.
+
+00:13:25.339 --> 00:13:33.209
+There's endless assaults, poison gas, nerve
+gas, morphine, burning streams of gasoline,
+
+00:13:33.209 --> 00:13:38.510
+scavenging and scabbing for food, influenza,
+typhus, dysentery.
+
+00:13:38.510 --> 00:13:42.720
+Life is breaking down all around you, and
+the shells are whistling.
+
+00:13:42.720 --> 00:13:45.870
+This is the lower region of hell.
+
+00:13:45.870 --> 00:13:52.920
+Mud, barbed wire, rat-filled trenches, rats
+eating the intestines of dead men, trenches
+
+00:13:52.920 --> 00:13:55.149
+filled with filth and excrement.
+
+00:13:55.149 --> 00:13:57.589
+Someone shouts, "Hey, you there.
+
+00:13:57.589 --> 00:13:59.170
+Stand and fight."
+
+00:13:59.170 --> 00:14:01.509
+Who knows how long this mess will go on?
+
+00:14:01.509 --> 00:14:03.310
+Warfare has no limits.
+
+00:14:03.310 --> 00:14:07.370
+You're being annihilated, and that leg of
+yours is bleeding too much.
+
+00:14:07.370 --> 00:14:10.290
+You killed a man yesterday, and you spoke
+to his corpse.
+
+00:14:10.290 --> 00:14:17.519
+You told him after this is over, you'll spend
+the rest of your life looking after his family.
+
+00:14:17.519 --> 00:14:18.690
+Who's profiting here?
+
+00:14:18.690 --> 00:14:23.310
+The leaders and the generals gain fame, and
+many others profit financially.
+
+00:14:23.310 --> 00:14:26.290
+But you're doing the dirty work.
+
+00:14:26.290 --> 00:14:29.140
+One of your comrades says, "Wait a minute,
+where are you going?"
+
+00:14:29.140 --> 00:14:32.879
+And you say, "Leave me alone, I'll be back
+in a minute."
+
+00:14:32.879 --> 00:14:37.930
+Then you walk out into the woods of death
+hunting for a piece of sausage.
+
+00:14:37.930 --> 00:14:42.459
+You can't see how anybody in civilian life
+has any kind of purpose at all.
+
+00:14:42.459 --> 00:14:46.829
+All their worries, all their desires - you
+can't comprehend it.
+
+00:14:46.829 --> 00:14:52.000
+More machine guns rattle, more parts of bodies
+hanging from wires, more pieces of arms and
+
+00:14:52.000 --> 00:14:58.399
+legs and skulls where butterflies perch on
+teeth, more hideous wounds, pus coming out
+
+00:14:58.399 --> 00:15:04.930
+of every pore, lung wounds, wounds too big
+for the body, gas-blowing cadavers, and dead
+
+00:15:04.930 --> 00:15:06.959
+bodies making retching noises.
+
+00:15:06.959 --> 00:15:09.720
+Death is everywhere.
+
+00:15:09.720 --> 00:15:11.820
+Nothing else is possible.
+
+00:15:11.820 --> 00:15:15.380
+Someone will kill you and use your dead body
+for target practice.
+
+00:15:15.380 --> 00:15:16.380
+Boots, too.
+
+00:15:16.380 --> 00:15:17.380
+They're your prized possession.
+
+00:15:17.380 --> 00:15:21.690
+But soon they'll be on somebody else's feet.
+
+00:15:21.690 --> 00:15:23.740
+There's Froggies coming through the trees.
+
+00:15:23.740 --> 00:15:25.089
+Merciless bastards.
+
+00:15:25.089 --> 00:15:26.899
+Your shells are running out.
+
+00:15:26.899 --> 00:15:30.829
+"It's not fair to come at us again so soon,"
+you say.
+
+00:15:30.829 --> 00:15:36.250
+One of your companions is laying in the dirt,
+and you want to take him to the field hospital.
+
+00:15:36.250 --> 00:15:39.579
+Someone else says, "You might save yourself
+a trip."
+
+00:15:39.579 --> 00:15:41.231
+"What do you mean?"
+
+00:15:41.231 --> 00:15:43.660
+"Turn him over, you'll see what I mean."
+
+00:15:43.660 --> 00:15:44.980
+You wait to hear the news.
+
+00:15:44.980 --> 00:15:48.830
+You don't understand why the war isn't over.
+
+00:15:48.830 --> 00:15:53.542
+The army is so strapped for replacement troops
+that they're drafting young boys who are of
+
+00:15:53.542 --> 00:15:58.579
+little military use, but they're draftin'
+'em anyway because they're running out of
+
+00:15:58.579 --> 00:15:59.579
+men.
+
+00:15:59.579 --> 00:16:02.600
+Sickness and humiliation have broken your
+heart.
+
+00:16:02.600 --> 00:16:11.960
+You were betrayed by your parents, your schoolmasters,
+your ministers, and even your own government.
+
+00:16:11.960 --> 00:16:18.930
+The general with the slowly smoked cigar betrayed
+you too - turned you into a thug and a murderer.
+
+00:16:18.930 --> 00:16:21.860
+If you could, you'd put a bullet in his face.
+
+00:16:21.860 --> 00:16:23.759
+The commander as well.
+
+00:16:23.759 --> 00:16:29.070
+You fantasize that if you had the money, you'd
+put up a reward for any man who would take
+
+00:16:29.070 --> 00:16:31.170
+his life by any means necessary.
+
+00:16:31.170 --> 00:16:37.250
+And if he should lose his life by doing that,
+then let the money go to his heirs.
+
+00:16:37.250 --> 00:16:42.480
+The colonel, too, with his caviar and his
+coffee - he's another one.
+
+00:16:42.480 --> 00:16:44.420
+Spends all his time in the officers' brothel.
+
+00:16:44.420 --> 00:16:48.209
+You'd like to see him stoned dead too.
+
+00:16:48.209 --> 00:16:52.769
+More Tommies and Johnnies with their whack
+fo' me daddy-o and their whiskey in the jars.
+
+00:16:52.769 --> 00:16:56.880
+You kill twenty of 'em and twenty more will
+spring up in their place.
+
+00:16:56.880 --> 00:16:59.370
+It just stinks in your nostrils.
+
+00:16:59.370 --> 00:17:04.650
+You've come to despise that older generation
+that sent you out into this madness, into
+
+00:17:04.650 --> 00:17:06.339
+this torture chamber.
+
+00:17:06.339 --> 00:17:07.880
+All around you, your comrades are dying.
+
+00:17:07.880 --> 00:17:16.390
+Dying from abdominal wounds, double amputations,
+shattered hipbones, and you think, "I'm only
+
+00:17:16.390 --> 00:17:20.260
+twenty years old, but I'm capable of killing
+anybody.
+
+00:17:20.260 --> 00:17:23.830
+Even my father if he came at me."
+
+00:17:23.830 --> 00:17:30.840
+Yesterday, you tried to save a wounded messenger
+dog, and somebody shouted, "Don't be a fool."
+
+00:17:30.840 --> 00:17:34.680
+One Froggy is laying gurgling at your feet.
+
+00:17:34.680 --> 00:17:39.670
+You stuck him with a dagger in his stomach,
+but the man still lives.
+
+00:17:39.670 --> 00:17:43.340
+You know you should finish the job, but you
+can't.
+
+00:17:43.340 --> 00:17:49.010
+You're on the real iron cross, and a Roman
+soldier's putting a sponge of vinegar to your
+
+00:17:49.010 --> 00:17:50.010
+lips.
+
+00:17:50.010 --> 00:17:51.320
+Months pass by.
+
+00:17:51.320 --> 00:17:53.140
+You go home on leave.
+
+00:17:53.140 --> 00:17:55.190
+You can't communicate with your father.
+
+00:17:55.190 --> 00:17:57.710
+He said, "You'd be a coward if you don't enlist."
+
+00:17:57.710 --> 00:18:03.970
+Your mother, too, on your way back out the
+door, she says, "You be careful of those French
+
+00:18:03.970 --> 00:18:06.410
+girls now."
+
+00:18:06.410 --> 00:18:07.820
+More madness.
+
+00:18:07.820 --> 00:18:11.540
+You fight for a week or a month, and you gain
+ten yards.
+
+00:18:11.540 --> 00:18:15.790
+And then the next month it gets taken back.
+
+00:18:15.790 --> 00:18:22.260
+All that culture from a thousand years ago,
+that philosophy, that wisdom - Plato, Aristotle,
+
+00:18:22.260 --> 00:18:25.960
+Socrates - what happened to it?
+
+00:18:25.960 --> 00:18:27.750
+It should have prevented this.
+
+00:18:27.750 --> 00:18:29.380
+Your thoughts turn homeward.
+
+00:18:29.380 --> 00:18:34.580
+And once again you're a schoolboy walking
+through the tall poplar trees.
+
+00:18:34.580 --> 00:18:36.780
+It's a pleasant memory.
+
+00:18:36.780 --> 00:18:38.830
+More bombs dropping on you from blimps.
+
+00:18:38.830 --> 00:18:40.890
+You got to get it together now.
+
+00:18:40.890 --> 00:18:46.560
+You can't even look at anybody for fear of
+some miscalculable thing that might happen.
+
+00:18:46.560 --> 00:18:47.560
+The common grave.
+
+00:18:47.560 --> 00:18:51.260
+There are no other possibilities.
+
+00:18:51.260 --> 00:18:57.000
+Then you notice the cherry blossoms, and you
+see that nature is unaffected by all this.
+
+00:18:57.000 --> 00:19:02.370
+Poplar trees, the red butterflies, the fragile
+beauty of flowers, the sun - you see how nature
+
+00:19:02.370 --> 00:19:04.630
+is indifferent to it all.
+
+00:19:04.630 --> 00:19:07.550
+All the violence and suffering of all mankind.
+
+00:19:07.550 --> 00:19:09.150
+Nature doesn't even notice it.
+
+00:19:09.150 --> 00:19:10.440
+You're so alone.
+
+00:19:10.440 --> 00:19:15.020
+Then a piece of shrapnel hits the side of
+your head and you're dead.
+
+00:19:15.020 --> 00:19:18.150
+You've been ruled out, crossed out.
+
+00:19:18.150 --> 00:19:20.250
+You've been exterminated.
+
+00:19:20.250 --> 00:19:24.130
+I put this book down and closed it up.
+
+00:19:24.130 --> 00:19:31.130
+I never wanted to read another war novel again,
+and I never did.
+
+00:19:31.130 --> 00:19:35.970
+Charlie Poole from North Carolina had a song
+that connected to all this.
+
+00:19:35.970 --> 00:19:41.150
+It's called "You Ain't Talkin' to Me," and
+the lyrics go like this:
+
+00:19:41.150 --> 00:19:44.890
+I saw a sign in a window walking up town one
+day.
+
+00:19:44.890 --> 00:19:47.910
+Join the army, see the world is what it had
+to say.
+
+00:19:47.910 --> 00:19:54.200
+You'll see exciting places with a jolly crew,
+You'll meet interesting people, and learn
+
+00:19:54.200 --> 00:19:55.200
+to kill them too.
+
+00:19:55.200 --> 00:19:58.440
+Oh you ain't talkin' to me, you ain't talking
+to me.
+
+00:19:58.440 --> 00:20:02.520
+I may be crazy and all that, but I got good
+sense you see.
+
+00:20:02.520 --> 00:20:05.760
+You ain't talkin' to me, you ain't talkin'
+to me.
+
+00:20:05.760 --> 00:20:08.100
+Killin' with a gun don't sound like fun.
+
+00:20:08.100 --> 00:20:14.750
+You ain't talkin' to me.
+
+00:20:14.750 --> 00:20:18.640
+The Odyssey is a great book whose themes have
+worked its way into the ballads of a lot of
+
+00:20:18.640 --> 00:20:24.580
+songwriters: "Homeward Bound, "Green, Green
+Grass of Home," "Home on the Range," and my
+
+00:20:24.580 --> 00:20:26.640
+songs as well.
+
+00:20:26.640 --> 00:20:31.840
+The Odyssey is a strange, adventurous tale
+of a grown man trying to get home after fighting
+
+00:20:31.840 --> 00:20:33.620
+in a war.
+
+00:20:33.620 --> 00:20:38.190
+He's on that long journey home, and it's filled
+with traps and pitfalls.
+
+00:20:38.190 --> 00:20:40.380
+He's cursed to wander.
+
+00:20:40.380 --> 00:20:45.800
+He's always getting carried out to sea, always
+having close calls.
+
+00:20:45.800 --> 00:20:48.740
+Huge chunks of boulders rock his boat.
+
+00:20:48.740 --> 00:20:51.160
+He angers people he shouldn't.
+
+00:20:51.160 --> 00:20:54.130
+There's troublemakers in his crew.
+
+00:20:54.130 --> 00:20:55.570
+Treachery.
+
+00:20:55.570 --> 00:21:01.290
+His men are turned into pigs and then are
+turned back into younger, more handsome men.
+
+00:21:01.290 --> 00:21:03.760
+He's always trying to rescue somebody.
+
+00:21:03.760 --> 00:21:08.580
+He's a travelin' man, but he's making a lot
+of stops.
+
+00:21:08.580 --> 00:21:10.600
+He's stranded on a desert island.
+
+00:21:10.600 --> 00:21:13.540
+He finds deserted caves, and he hides in them.
+
+00:21:13.540 --> 00:21:16.440
+He meets giants that say, "I'll eat you last."
+
+00:21:16.440 --> 00:21:19.280
+And he escapes from giants.
+
+00:21:19.280 --> 00:21:23.670
+He's trying to get back home, but he's tossed
+and turned by the winds.
+
+00:21:23.670 --> 00:21:27.990
+Restless winds, chilly winds, unfriendly winds.
+
+00:21:27.990 --> 00:21:32.080
+He travels far, and then he gets blown back.
+
+00:21:32.080 --> 00:21:34.930
+He's always being warned of things to come.
+
+00:21:34.930 --> 00:21:36.810
+Touching things he's told not to.
+
+00:21:36.810 --> 00:21:39.950
+There's two roads to take, and they're both
+bad.
+
+00:21:39.950 --> 00:21:40.970
+Both hazardous.
+
+00:21:40.970 --> 00:21:46.550
+On one you could drown and on the other you
+could starve.
+
+00:21:46.550 --> 00:21:52.180
+He goes into the narrow straits with foaming
+whirlpools that swallow him.
+
+00:21:52.180 --> 00:21:55.830
+Meets six-headed monsters with sharp fangs.
+
+00:21:55.830 --> 00:21:58.460
+Thunderbolts strike at him.
+
+00:21:58.460 --> 00:22:03.170
+Overhanging branches that he makes a leap
+to reach for to save himself from a raging
+
+00:22:03.170 --> 00:22:05.380
+river.
+
+00:22:05.380 --> 00:22:10.070
+Goddesses and gods protect him, but some others
+want to kill him.
+
+00:22:10.070 --> 00:22:12.070
+He changes identities.
+
+00:22:12.070 --> 00:22:13.260
+He's exhausted.
+
+00:22:13.260 --> 00:22:17.620
+He falls asleep, and he's woken up by the
+sound of laughter.
+
+00:22:17.620 --> 00:22:19.730
+He tells his story to strangers.
+
+00:22:19.730 --> 00:22:22.140
+He's been gone twenty years.
+
+00:22:22.140 --> 00:22:24.300
+He was carried off somewhere and left there.
+
+00:22:24.300 --> 00:22:27.140
+Drugs have been dropped into his wine.
+
+00:22:27.140 --> 00:22:29.460
+It's been a hard road to travel.
+
+00:22:29.460 --> 00:22:34.200
+In a lot of ways, some of these same things
+have happened to you.
+
+00:22:34.200 --> 00:22:37.130
+You too have had drugs dropped into your wine.
+
+00:22:37.130 --> 00:22:39.750
+You too have shared a bed with the wrong woman.
+
+00:22:39.750 --> 00:22:46.530
+You too have been spellbound by magical voices,
+sweet voices with strange melodies.
+
+00:22:46.530 --> 00:22:50.550
+You too have come so far and have been so
+far blown back.
+
+00:22:50.550 --> 00:22:53.890
+And you've had close calls as well.
+
+00:22:53.890 --> 00:22:56.300
+You have angered people you should not have.
+
+00:22:56.300 --> 00:22:59.770
+And you too have rambled this country all
+around.
+
+00:22:59.770 --> 00:23:04.820
+And you've also felt that ill wind, the one
+that blows you no good.
+
+00:23:04.820 --> 00:23:06.470
+And that's still not all of it.
+
+00:23:06.470 --> 00:23:10.460
+When he gets back home, things aren't any
+better.
+
+00:23:10.460 --> 00:23:15.570
+Scoundrels have moved in and are taking advantage
+of his wife's hospitality.
+
+00:23:15.570 --> 00:23:17.870
+And there's too many of 'em.
+
+00:23:17.870 --> 00:23:23.290
+And though he's greater than them all and
+the best at everything - best carpenter, best
+
+00:23:23.290 --> 00:23:30.870
+hunter, best expert on animals, best seaman
+- his courage won't save him, but his trickery
+
+00:23:30.870 --> 00:23:31.870
+will.
+
+00:23:31.870 --> 00:23:36.710
+All these stragglers will have to pay for
+desecrating his palace.
+
+00:23:36.710 --> 00:23:41.860
+He'll disguise himself as a filthy beggar,
+and a lowly servant kicks him down the steps
+
+00:23:41.860 --> 00:23:44.420
+with arrogance and stupidity.
+
+00:23:44.420 --> 00:23:49.530
+The servant's arrogance revolts him, but he
+controls his anger.
+
+00:23:49.530 --> 00:23:55.570
+He's one against a hundred, but they'll all
+fall, even the strongest.
+
+00:23:55.570 --> 00:23:56.620
+He was nobody.
+
+00:23:56.620 --> 00:24:03.470
+And when it's all said and done, when he's
+home at last, he sits with his wife, and he
+
+00:24:03.470 --> 00:24:05.320
+tells her the stories.
+
+00:24:05.320 --> 00:24:08.300
+So what does it all mean?
+
+00:24:08.300 --> 00:24:12.830
+Myself and a lot of other songwriters have
+been influenced by these very same themes.
+
+00:24:12.830 --> 00:24:15.560
+And they can mean a lot of different things.
+
+00:24:15.560 --> 00:24:19.120
+If a song moves you, that's all that's important.
+
+00:24:19.120 --> 00:24:21.000
+I don't have to know what a song means.
+
+00:24:21.000 --> 00:24:24.180
+I've written all kinds of things into my songs.
+
+00:24:24.180 --> 00:24:27.190
+And I'm not going to worry about it - what
+it all means.
+
+00:24:27.190 --> 00:24:34.050
+When Melville put all his old testament, biblical
+references, scientific theories, Protestant
+
+00:24:34.050 --> 00:24:40.320
+doctrines, and all that knowledge of the sea
+and sailing ships and whales into one story,
+
+00:24:40.320 --> 00:24:45.930
+I don't think he would have worried about
+it either - what it all means.
+
+00:24:45.930 --> 00:24:51.850
+John Donne as well, the poet-priest who lived
+in the time of Shakespeare, wrote these words,
+
+00:24:51.850 --> 00:24:55.540
+"The Sestos and Abydos of her breasts.
+
+00:24:55.540 --> 00:24:59.330
+Not of two lovers, but two loves, the nests."
+
+00:24:59.330 --> 00:25:01.830
+I don't know what it means, either.
+
+00:25:01.830 --> 00:25:03.260
+But it sounds good.
+
+00:25:03.260 --> 00:25:06.800
+And you want your songs to sound good.
+
+00:25:06.800 --> 00:25:13.490
+When Odysseus in The Odyssey visits the famed
+warrior Achilles in the underworld - Achilles,
+
+00:25:13.490 --> 00:25:19.660
+who traded a long life full of peace and contentment
+for a short one full of honor and glory - tells
+
+00:25:19.660 --> 00:25:22.990
+Odysseus it was all a mistake.
+
+00:25:22.990 --> 00:25:24.790
+"I just died, that's all."
+
+00:25:24.790 --> 00:25:26.650
+There was no honor.
+
+00:25:26.650 --> 00:25:28.510
+No immortality.
+
+00:25:28.510 --> 00:25:34.120
+And that if he could, he would choose to go
+back and be a lowly slave to a tenant farmer
+
+00:25:34.120 --> 00:25:41.600
+on Earth rather than be what he is - a king
+in the land of the dead - that whatever his
+
+00:25:41.600 --> 00:25:49.600
+struggles of life were, they were preferable
+to being here in this dead place.
+
+00:25:49.600 --> 00:25:51.250
+That's what songs are too.
+
+00:25:51.250 --> 00:25:54.320
+Our songs are alive in the land of the living.
+
+00:25:54.320 --> 00:25:56.600
+But songs are unlike literature.
+
+00:25:56.600 --> 00:25:59.510
+They're meant to be sung, not read.
+
+00:25:59.510 --> 00:26:03.020
+The words in Shakespeare's plays were meant
+to be acted on the stage.
+
+00:26:03.020 --> 00:26:09.160
+Just as lyrics in songs are meant to be sung,
+not read on a page.
+
+00:26:09.160 --> 00:26:13.410
+And I hope some of you get the chance to listen
+to these lyrics the way they were intended
+
+00:26:13.410 --> 00:26:19.950
+to be heard: in concert or on record or however
+people are listening to songs these days.
+
+00:26:19.950 --> 00:26:26.650
+I return once again to Homer, who says, "Sing
+in me, oh Muse, and through me tell the story."
+


### PR DESCRIPTION
## Why was this change made? 🤔

Take a similar approach to identifying `application/json` files in #50 to allow `.vtt` files to always return the `text/vtt` media type.

Fixes #119

Refs https://github.com/sul-dlss/sul-embed/pull/1469

## How was this change tested? 🤨

Unit tests.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do file accessioning*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



